### PR TITLE
EVSRESTAPI-114

### DIFF
--- a/software/evsrestapi-util/src/gov/nih/nci/evs/restapi/common/Constants.java
+++ b/software/evsrestapi-util/src/gov/nih/nci/evs/restapi/common/Constants.java
@@ -78,7 +78,7 @@ public class Constants {
 
 	public static final String EVSRESTAPI_BEAN = "gov.nih.nci.evs.restapi.bean";
 
-    public static String[] COMMON_PROPERTIES = {"code", "label", "Preferred_Name", "Display_Name", "DEFINITION", "ALT_DEFINITION",
+    public static String[] COMMON_PROPERTIES = {"code", "name", "Preferred_Name", "Display_Name", "DEFINITION", "ALT_DEFINITION",
                                                 "FULL_SYN", "Concept_Status", "Semantic_Type"};
 
 	public static String DEFAULT_VERSION_PREDICATE = "owl:versionInfo";

--- a/software/evsrestapi-util/src/gov/nih/nci/evs/restapi/common/Constants.java
+++ b/software/evsrestapi-util/src/gov/nih/nci/evs/restapi/common/Constants.java
@@ -78,7 +78,7 @@ public class Constants {
 
 	public static final String EVSRESTAPI_BEAN = "gov.nih.nci.evs.restapi.bean";
 
-    public static String[] COMMON_PROPERTIES = {"code", "name", "Preferred_Name", "Display_Name", "DEFINITION", "ALT_DEFINITION",
+    public static String[] COMMON_PROPERTIES = {"code", "label", "Preferred_Name", "Display_Name", "DEFINITION", "ALT_DEFINITION",
                                                 "FULL_SYN", "Concept_Status", "Semantic_Type"};
 
 	public static String DEFAULT_VERSION_PREDICATE = "owl:versionInfo";

--- a/src/main/java/gov/nih/nci/evs/api/controller/MetadataController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/MetadataController.java
@@ -129,7 +129,7 @@ public class MetadataController extends BaseController {
    * @return the association
    * @throws Exception the exception
    */
-  @ApiOperation(value = "Get the association for the specified terminology and code/label",
+  @ApiOperation(value = "Get the association for the specified terminology and code/name",
       response = Concept.class)
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Successfully retrieved the requested information"),
@@ -139,8 +139,8 @@ public class MetadataController extends BaseController {
   @ApiImplicitParams({
       @ApiImplicitParam(name = "terminology", value = "Terminology, e.g. 'ncit'", required = true,
           dataType = "string", paramType = "path", defaultValue = "ncit"),
-      @ApiImplicitParam(name = "codeOrLabel",
-          value = "Association code (or label), e.g. 'A10' or 'Has_CDRH_Parent'", required = true,
+      @ApiImplicitParam(name = "codeOrName",
+          value = "Association code (or name), e.g. 'A10' or 'Has_CDRH_Parent'", required = true,
           dataType = "string", paramType = "path"),
       @ApiImplicitParam(name = "include",
           value = "Indicator of how much data to return. Comma-separated list of any of the following values: "
@@ -152,10 +152,10 @@ public class MetadataController extends BaseController {
   })
   @RecordMetric
   @RequestMapping(method = RequestMethod.GET,
-      value = "/metadata/{terminology}/association/{codeOrLabel}", produces = "application/json")
+      value = "/metadata/{terminology}/association/{codeOrName}", produces = "application/json")
   public @ResponseBody Concept getAssociation(
     @PathVariable(value = "terminology") final String terminology,
-    @PathVariable(value = "codeOrLabel") final String code,
+    @PathVariable(value = "codeOrName") final String code,
     @RequestParam("include") final Optional<String> include) throws Exception {
     try {
 
@@ -231,7 +231,7 @@ public class MetadataController extends BaseController {
    * @return the role
    * @throws Exception the exception
    */
-  @ApiOperation(value = "Get the role for the specified terminology and code/label",
+  @ApiOperation(value = "Get the role for the specified terminology and code/name",
       response = Concept.class)
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Successfully retrieved the requested information"),
@@ -241,8 +241,8 @@ public class MetadataController extends BaseController {
   @ApiImplicitParams({
       @ApiImplicitParam(name = "terminology", value = "Terminology, e.g. 'ncit'", required = true,
           dataType = "string", paramType = "path", defaultValue = "ncit"),
-      @ApiImplicitParam(name = "codeOrLabel",
-          value = "Role code (or label), e.g. 'R123' or 'Chemotherapy_Regimen_Has_Component'",
+      @ApiImplicitParam(name = "codeOrName",
+          value = "Role code (or name), e.g. 'R123' or 'Chemotherapy_Regimen_Has_Component'",
           required = true, dataType = "string", paramType = "path"),
       @ApiImplicitParam(name = "include",
           value = "Indicator of how much data to return. Comma-separated list of any of the following values: "
@@ -253,11 +253,11 @@ public class MetadataController extends BaseController {
           required = false, dataType = "string", paramType = "query", defaultValue = "summary")
   })
   @RecordMetric
-  @RequestMapping(method = RequestMethod.GET, value = "/metadata/{terminology}/role/{codeOrLabel}",
+  @RequestMapping(method = RequestMethod.GET, value = "/metadata/{terminology}/role/{codeOrName}",
       produces = "application/json")
   public @ResponseBody Concept getRole(
     @PathVariable(value = "terminology") final String terminology,
-    @PathVariable(value = "codeOrLabel") final String code,
+    @PathVariable(value = "codeOrName") final String code,
     @RequestParam("include") final Optional<String> include) throws Exception {
     try {
       // If the code contains a comma, just bail
@@ -379,7 +379,7 @@ public class MetadataController extends BaseController {
    * @return the qualifier
    * @throws Exception the exception
    */
-  @ApiOperation(value = "Get the qualifier for the specified terminology and code/label",
+  @ApiOperation(value = "Get the qualifier for the specified terminology and code/name",
       response = Concept.class)
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Successfully retrieved the requested information"),
@@ -389,8 +389,8 @@ public class MetadataController extends BaseController {
   @ApiImplicitParams({
       @ApiImplicitParam(name = "terminology", value = "Terminology, e.g. 'ncit'", required = true,
           dataType = "string", paramType = "path", defaultValue = "ncit"),
-      @ApiImplicitParam(name = "codeOrLabel",
-          value = "Qualifier code (or label), e.g. 'P390' or 'go-source'", required = true,
+      @ApiImplicitParam(name = "codeOrName",
+          value = "Qualifier code (or name), e.g. 'P390' or 'go-source'", required = true,
           dataType = "string", paramType = "path"),
       @ApiImplicitParam(name = "include",
           value = "Indicator of how much data to return. Comma-separated list of any of the following values: "
@@ -402,10 +402,10 @@ public class MetadataController extends BaseController {
   })
   @RecordMetric
   @RequestMapping(method = RequestMethod.GET,
-      value = "/metadata/{terminology}/qualifier/{codeOrLabel}", produces = "application/json")
+      value = "/metadata/{terminology}/qualifier/{codeOrName}", produces = "application/json")
   public @ResponseBody Concept getQualifier(
     @PathVariable(value = "terminology") final String terminology,
-    @PathVariable(value = "codeOrLabel") final String code,
+    @PathVariable(value = "codeOrName") final String code,
     @RequestParam("include") final Optional<String> include) throws Exception {
 
     try {
@@ -465,7 +465,7 @@ public class MetadataController extends BaseController {
    * @return the property
    * @throws Exception the exception
    */
-  @ApiOperation(value = "Get the property for the specified terminology and code/label",
+  @ApiOperation(value = "Get the property for the specified terminology and code/name",
       response = Concept.class)
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Successfully retrieved the requested information"),
@@ -475,8 +475,8 @@ public class MetadataController extends BaseController {
   @ApiImplicitParams({
       @ApiImplicitParam(name = "terminology", value = "Terminology, e.g. 'ncit'", required = true,
           dataType = "string", paramType = "path", defaultValue = "ncit"),
-      @ApiImplicitParam(name = "codeOrLabel",
-          value = "Property code (or label), e.g. 'P90' or 'FULL_SYN'", required = true,
+      @ApiImplicitParam(name = "codeOrName",
+          value = "Property code (or name), e.g. 'P90' or 'FULL_SYN'", required = true,
           dataType = "string", paramType = "path"),
       @ApiImplicitParam(name = "include",
           value = "Indicator of how much data to return. Comma-separated list of any of the following values: "
@@ -488,10 +488,10 @@ public class MetadataController extends BaseController {
   })
   @RecordMetric
   @RequestMapping(method = RequestMethod.GET,
-      value = "/metadata/{terminology}/property/{codeOrLabel}", produces = "application/json")
+      value = "/metadata/{terminology}/property/{codeOrName}", produces = "application/json")
   public @ResponseBody Concept getProperty(
     @PathVariable(value = "terminology") final String terminology,
-    @PathVariable(value = "codeOrLabel") final String code,
+    @PathVariable(value = "codeOrName") final String code,
     @RequestParam("include") final Optional<String> include) throws Exception {
 
     try {
@@ -617,7 +617,7 @@ public class MetadataController extends BaseController {
    * @return the axiom qualifiers list
    * @throws Exception the exception
    */
-  @ApiOperation(value = "Get qualifier values for the specified terminology and code/label",
+  @ApiOperation(value = "Get qualifier values for the specified terminology and code/name",
       response = String.class, responseContainer = "List")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Successfully retrieved the requested information"),
@@ -627,17 +627,17 @@ public class MetadataController extends BaseController {
   @ApiImplicitParams({
       @ApiImplicitParam(name = "terminology", value = "Terminology, e.g. 'ncit'", required = true,
           dataType = "string", paramType = "path", defaultValue = "ncit"),
-      @ApiImplicitParam(name = "codeOrLabel",
-          value = "Qualifier code (or label), e.g. 'P383' or 'term-group'", required = true,
+      @ApiImplicitParam(name = "codeOrName",
+          value = "Qualifier code (or name), e.g. 'P383' or 'term-group'", required = true,
           dataType = "string", paramType = "path")
   })
   @RecordMetric
   @RequestMapping(method = RequestMethod.GET,
-      value = "/metadata/{terminology}/qualifier/{codeOrLabel}/values",
+      value = "/metadata/{terminology}/qualifier/{codeOrName}/values",
       produces = "application/json")
   public @ResponseBody List<String> getQualifierValues(
     @PathVariable(value = "terminology") final String terminology,
-    @PathVariable(value = "codeOrLabel") final String code) throws Exception {
+    @PathVariable(value = "codeOrName") final String code) throws Exception {
     try {
       // If the code contains a comma, just bail
       if (code.contains(",")) {

--- a/src/main/java/gov/nih/nci/evs/api/controller/SearchController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/SearchController.java
@@ -111,7 +111,7 @@ public class SearchController extends BaseController {
           value = "Comma-separated list of concept status values to restrict search results to. <a href='api/v1/metadata/ncit/conceptStatuses' target='_blank'>Click here for a list of NCI Thesaurus values.</a>",
           required = false, dataType = "string", paramType = "query", defaultValue = ""),
       @ApiImplicitParam(name = "property",
-          value = "Comma-separated list of properties to search. e.g P107,P108. <a href='api/v1/metadata/ncit/properties' target='_blank'>Click here for a list of NCI Thesaurus properties.</a>.The properties can be specified as code or label",
+          value = "Comma-separated list of properties to search. e.g P107,P108. <a href='api/v1/metadata/ncit/properties' target='_blank'>Click here for a list of NCI Thesaurus properties.</a>.The properties can be specified as code or name",
           required = false, dataType = "string", paramType = "query", defaultValue = ""),
       @ApiImplicitParam(name = "definitionSource",
           value = "Comma-separated list of definition sources to restrict search results to.",
@@ -131,12 +131,12 @@ public class SearchController extends BaseController {
       // of associations to search. e.g A10,A215. <a
       // href='api/v1/metadata/ncit/associations' target='_blank'>Click here for
       // a list of NCI Thesaurus associations.</a>. The associations can be
-      // specified as code or label", required = false, dataType = "string",
+      // specified as code or name", required = false, dataType = "string",
       // paramType = "query", defaultValue = ""),
       // @ApiImplicitParam(name = "role", value = "Comma-separated list of roles
       // to search. e.g R15,R193. <a href='api/v1/metadata/ncit/roles'
       // target='_blank'>Click here for a list of NCI Thesaurus roles.</a>. The
-      // roles can be specified as code or label", required = false, dataType =
+      // roles can be specified as code or name", required = false, dataType =
       // "string", paramType = "query", defaultValue = "")
   })
   @RecordMetric
@@ -189,7 +189,7 @@ public class SearchController extends BaseController {
           value = "Comma-separated list of concept status values to restrict search results to. <a href='api/v1/metadata/ncit/conceptStatuses' target='_blank'>Click here for a list of NCI Thesaurus values.</a>",
           required = false, dataType = "string", paramType = "query", defaultValue = ""),
       @ApiImplicitParam(name = "property",
-          value = "Comma-separated list of properties to search. e.g P107,P108. <a href='api/v1/metadata/ncit/properties' target='_blank'>Click here for a list of NCI Thesaurus properties.</a>.The properties can be specified as code or label",
+          value = "Comma-separated list of properties to search. e.g P107,P108. <a href='api/v1/metadata/ncit/properties' target='_blank'>Click here for a list of NCI Thesaurus properties.</a>.The properties can be specified as code or name",
           required = false, dataType = "string", paramType = "query", defaultValue = ""),
       @ApiImplicitParam(name = "definitionSource",
           value = "Comma-separated list of definition sources to restrict search results to.",
@@ -209,12 +209,12 @@ public class SearchController extends BaseController {
       // of associations to search. e.g A10,A215. <a
       // href='api/v1/metadata/ncit/associations' target='_blank'>Click here for
       // a list of NCI Thesaurus associations.</a>. The associations can be
-      // specified as code or label", required = false, dataType = "string",
+      // specified as code or name", required = false, dataType = "string",
       // paramType = "query", defaultValue = ""),
       // @ApiImplicitParam(name = "role", value = "Comma-separated list of roles
       // to search. e.g R15,R193. <a href='api/v1/metadata/ncit/roles'
       // target='_blank'>Click here for a list of NCI Thesaurus roles.</a>. The
-      // roles can be specified as code or label", required = false, dataType =
+      // roles can be specified as code or name", required = false, dataType =
       // "string", paramType = "query", defaultValue = "")
   })
   @RecordMetric

--- a/src/main/java/gov/nih/nci/evs/api/model/Concept.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Concept.java
@@ -10,6 +10,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -46,6 +47,7 @@ import gov.nih.nci.evs.api.service.ElasticOperationsService;
  */
 @Document(indexName = "default", type = ElasticOperationsService.CONCEPT_TYPE)
 @JsonInclude(Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Concept extends ConceptMinimal {
 
   /** The highlight. */

--- a/src/main/java/gov/nih/nci/evs/api/model/Property.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Property.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 public class Property extends BaseModel {
 
   /** The code. */
-  @Field(type = FieldType.Text)
+  @Field(type = FieldType.Text, store=false)
   private String code;
 
   /** The type. */

--- a/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
@@ -1,6 +1,9 @@
 
 package gov.nih.nci.evs.api.model;
 
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
@@ -13,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Qualifier extends BaseModel {
 
   /** The code. */
+  @Field(type = FieldType.Text, store=false)
   private String code;
 
   /** The type. */

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -576,6 +576,7 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
       Concept c = new Concept();
       c.setCode(b.getConceptCode().getValue());
       c.setTerminology(terminology.getTerminology());
+      c.setVersion(terminology.getVersion());
       c.setName(b.getConceptLabel().getValue());
       concepts.add(c);
     }

--- a/src/main/java/gov/nih/nci/evs/api/util/EVSUtils.java
+++ b/src/main/java/gov/nih/nci/evs/api/util/EVSUtils.java
@@ -109,6 +109,7 @@ public class EVSUtils {
         definition.setDefinition(axiom.getAnnotatedTarget());
         definition.setSource(axiom.getDefSource());
         definition.getQualifiers().addAll(axiom.getQualifiers());
+        definition.setType("DEFINITION");
         results.add(definition);
       }
       // TODO: CONFIG

--- a/src/main/java/gov/nih/nci/evs/api/util/EVSUtils.java
+++ b/src/main/java/gov/nih/nci/evs/api/util/EVSUtils.java
@@ -65,7 +65,7 @@ public class EVSUtils {
   public static Set<String> getCommonPropertyNames(Terminology terminology) {
     // TODO: CONFIG
     return new HashSet<>(Arrays.asList(new String[] {
-        "code", "label", "Preferred_Name", "DEFINITION", "ALT_DEFINITION", "FULL_SYN", "Maps_To"
+        "code", "name", "Preferred_Name", "DEFINITION", "ALT_DEFINITION", "FULL_SYN", "Maps_To"
     }));
   }
 

--- a/src/test/java/gov/nih/nci/evs/api/controller/QualifierTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/QualifierTests.java
@@ -371,8 +371,8 @@ public class QualifierTests {
     Concept concept = null;
 
     for (final String name : EVSUtils.getCommonPropertyNames(null)) {
-      // skip label
-      if (name.equals("label")) {
+      // skip name
+      if (name.equals("name")) {
         continue;
       }
       // Try P98 - expect to not find it as a property


### PR DESCRIPTION
1a. Consistency - code/type  (concept and metadata calls)
  - code -> use @Field(store=false) - properties, qualifier
  - type -> for definitions always show

1b. {codeOrLabel} -> rename this in swagger to {codeOrName}
  - find all uses of the word "label" and fix them.

1c. top-level concept call needs to include "version" - this probably
    needs to be put into elasticsearch index.