### PR TITLE
Evsrestapi115

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ bin/
 __pycache__
 /build/
 WEB-INF/*
+.idea/compiler.xml
+.idea/gradle.xml
+.idea/jarRepositories.xml
+.idea/misc.xml
+.idea/vcs.xml
+.vscode/launch.json
+.vscode/settings.json
+.idea/.gitignore

--- a/src/main/java/gov/nih/nci/evs/api/controller/ConceptController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/ConceptController.java
@@ -648,7 +648,6 @@ public class ConceptController extends BaseController {
     try {
       final Terminology term =
           TerminologyUtils.getTerminology(sparqlQueryManagerService, terminology);
-      final IncludeParam ip = new IncludeParam(include.orElse(null));
 
       final List<Concept> list = elasticQueryService.getRootNodes(term);
       if (list == null || list.isEmpty()) {

--- a/src/main/java/gov/nih/nci/evs/api/controller/ConceptController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/ConceptController.java
@@ -635,13 +635,12 @@ public class ConceptController extends BaseController {
           TerminologyUtils.getTerminology(sparqlQueryManagerService, terminology);
       final IncludeParam ip = new IncludeParam(include.orElse(null));
 
-      final List<HierarchyNode> list = elasticQueryService.getRootNodes(term);
+      final List<Concept> list = elasticQueryService.getRootNodes(term);
       if (list == null || list.isEmpty()) {
         throw new ResponseStatusException(HttpStatus.NOT_FOUND,
             "No roots for found for terminology = " + terminology);
       }
-      return ConceptUtils.convertConceptsFromHierarchyWithInclude(elasticQueryService, ip, term,
-          list);
+      return list;
     } catch (Exception e) {
       handleException(e);
       return null;

--- a/src/main/java/gov/nih/nci/evs/api/controller/ConceptController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/ConceptController.java
@@ -795,7 +795,7 @@ public class ConceptController extends BaseController {
       if (!elasticQueryService.checkConceptExists(code, term)) {
         throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Code not found = " + code);
       }
-      final List<HierarchyNode> nodes = elasticQueryService.getChildNodes(code, term);
+      final List<HierarchyNode> nodes = elasticQueryService.getChildNodes(code, 0, term);
       nodes.stream().peek(n -> n.setLevel(null)).count();
       return nodes;
     } catch (Exception e) {

--- a/src/main/java/gov/nih/nci/evs/api/service/ElasticQueryService.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/ElasticQueryService.java
@@ -101,8 +101,20 @@ public interface ElasticQueryService {
    * @throws JsonMappingException
    * @throws IOException
    */
-  List<HierarchyNode> getRootNodes(Terminology terminology) throws JsonParseException, JsonMappingException, IOException;
+  List<Concept> getRootNodes(Terminology terminology) throws JsonParseException, JsonMappingException, IOException;
   
+  
+/**
+   * see superclass *.
+   *
+   * @param terminology the terminology
+   * @return the root nodes
+   * @throws JsonParseException the json parse exception
+   * @throws JsonMappingException the json mapping exception
+   * @throws IOException Signals that an I/O exception has occurred.
+   */
+  List<HierarchyNode> getRootNodesHierarchy(Terminology terminology) throws JsonParseException, JsonMappingException, IOException;
+
   /**
    * Returns the child nodes
    * 
@@ -175,15 +187,15 @@ public interface ElasticQueryService {
   Paths getPathToParent(String code, String parentCode, Terminology terminology) throws JsonParseException, JsonMappingException, IOException;
   
   /**
-   * Get hiearchy for a given terminology.
+   * Get hiearchy roots for a given terminology.
    *
    * @param terminology the terminology
-   * @return the hierarchy
+   * @return the hierarchy roots
    * @throws JsonParseException the json parse exception
    * @throws JsonMappingException the json mapping exception
    * @throws IOException Signals that an I/O exception has occurred.
    */
-  Optional<HierarchyUtils> getHierarchy(Terminology terminology) throws JsonMappingException, JsonProcessingException;
+  public Optional<HierarchyUtils> getHierarchyRoots(Terminology terminology) throws JsonMappingException, JsonProcessingException;
   
   /**
    * Returns qualifiers

--- a/src/main/java/gov/nih/nci/evs/api/service/ElasticQueryService.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/ElasticQueryService.java
@@ -123,18 +123,6 @@ public interface ElasticQueryService {
    * @throws IOException Signals that an I/O exception has occurred.
    */
   List<HierarchyNode> getRootNodesHierarchy(Terminology terminology) throws JsonParseException, JsonMappingException, IOException;
-
-  /**
-   * Returns the child nodes
-   * 
-   * @param parent the parent code
-   * @param terminology the terminology
-   * @return the list of child nodes
-   * @throws JsonParseException
-   * @throws JsonMappingException
-   * @throws IOException
-   */
-  List<HierarchyNode> getChildNodes(String parent, Terminology terminology) throws JsonParseException, JsonMappingException, IOException;
   
   /**
    * Returns the child nodes

--- a/src/main/java/gov/nih/nci/evs/api/service/ElasticQueryServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/ElasticQueryServiceImpl.java
@@ -251,22 +251,6 @@ public class ElasticQueryServiceImpl implements ElasticQueryService {
    * see superclass *.
    *
    * @param parent the parent
-   * @param terminology the terminology
-   * @return the child nodes
-   * @throws JsonParseException the json parse exception
-   * @throws JsonMappingException the json mapping exception
-   * @throws IOException Signals that an I/O exception has occurred.
-   */
-  @Override
-  public List<HierarchyNode> getChildNodes(String parent, Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException {
-    return getChildNodes(parent, 0, terminology);
-  }
-
-  /**
-   * see superclass *.
-   *
-   * @param parent the parent
    * @param maxLevel the max level
    * @param terminology the terminology
    * @return the child nodes
@@ -417,7 +401,7 @@ public class ElasticQueryServiceImpl implements ElasticQueryService {
         ConceptNode cNode = cNodes.get(j);
         Concept c = conceptMap.get(cNode.getCode());
         if (!previous.getChildren().stream().anyMatch(n -> n.getCode().equals(c.getCode()))) {
-          List<HierarchyNode> children = getChildNodes(previous.getCode(), terminology);
+          List<HierarchyNode> children = getChildNodes(previous.getCode(), 0, terminology);
           for (HierarchyNode child : children) {
             child.setLevel(null);
             previous.getChildren().add(child);

--- a/src/main/java/gov/nih/nci/evs/api/service/ElasticQueryServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/ElasticQueryServiceImpl.java
@@ -476,25 +476,6 @@ public class ElasticQueryServiceImpl implements ElasticQueryService {
   }
 
   /**
-   * Returns the hierarchy node.
-   *
-   * @param concept the concept
-   * @param knownNodeMap the known node map
-   * @return the hierarchy node
-   */
-  private HierarchyNode getHierarchyNode(Concept concept, Map<String, HierarchyNode> knownNodeMap) {
-    HierarchyNode hNode = null;
-    if (knownNodeMap.containsKey(concept.getCode())) {
-      hNode = knownNodeMap.get(concept.getCode());
-    } else {
-      hNode = new HierarchyNode(concept.getCode(), concept.getName(), concept.getLeaf());
-      knownNodeMap.put(concept.getCode(), hNode);
-    }
-
-    return hNode;
-  }
-
-  /**
    * see superclass *.
    *
    * @param code the code

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerService.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerService.java
@@ -15,9 +15,7 @@ import gov.nih.nci.evs.api.model.Axiom;
 import gov.nih.nci.evs.api.model.Concept;
 import gov.nih.nci.evs.api.model.ConceptMinimal;
 import gov.nih.nci.evs.api.model.DisjointWith;
-import gov.nih.nci.evs.api.model.HierarchyNode;
 import gov.nih.nci.evs.api.model.IncludeParam;
-import gov.nih.nci.evs.api.model.Path;
 import gov.nih.nci.evs.api.model.Paths;
 import gov.nih.nci.evs.api.model.Property;
 import gov.nih.nci.evs.api.model.Role;
@@ -293,58 +291,6 @@ public interface SparqlQueryManagerService {
     throws IOException;
 
   /**
-   * Returns the root nodes.
-   *
-   * @param terminology the terminology
-   * @return the root nodes
-   * @throws JsonParseException the json parse exception
-   * @throws JsonMappingException the json mapping exception
-   * @throws IOException Signals that an I/O exception has occurred.
-   */
-  public List<HierarchyNode> getRootNodes(Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException;
-
-  /**
-   * Returns the child nodes.
-   *
-   * @param parent the parent
-   * @param terminology the terminology
-   * @return the child nodes
-   * @throws JsonParseException the json parse exception
-   * @throws JsonMappingException the json mapping exception
-   * @throws IOException Signals that an I/O exception has occurred.
-   */
-  public List<HierarchyNode> getChildNodes(String parent, Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException;
-
-  /**
-   * Returns the child nodes.
-   *
-   * @param parent the parent
-   * @param maxLevel the max level
-   * @param terminology the terminology
-   * @return the child nodes
-   * @throws JsonParseException the json parse exception
-   * @throws JsonMappingException the json mapping exception
-   * @throws IOException Signals that an I/O exception has occurred.
-   */
-  public List<HierarchyNode> getChildNodes(String parent, int maxLevel, Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException;
-
-  /**
-   * Returns the path in hierarchy.
-   *
-   * @param code the code
-   * @param terminology the terminology
-   * @return the path in hierarchy
-   * @throws JsonParseException the json parse exception
-   * @throws JsonMappingException the json mapping exception
-   * @throws IOException Signals that an I/O exception has occurred.
-   */
-  public List<HierarchyNode> getPathInHierarchy(String code, Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException;
-
-  /**
    * Returns the path to root.
    *
    * @param conceptCode the concept code
@@ -549,20 +495,6 @@ public interface SparqlQueryManagerService {
    * @throws IOException Signals that an I/O exception has occurred.
    */
   List<String> getAllChildNodes(String parent, Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException;
-
-  /**
-   * Check path in hierarchy.
-   *
-   * @param code the code
-   * @param node the node
-   * @param path the path
-   * @param terminology the terminology
-   * @throws JsonParseException the json parse exception
-   * @throws JsonMappingException the json mapping exception
-   * @throws IOException Signals that an I/O exception has occurred.
-   */
-  void checkPathInHierarchy(String code, HierarchyNode node, Path path, Terminology terminology)
     throws JsonParseException, JsonMappingException, IOException;
 
   /**

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -38,7 +38,6 @@ import gov.nih.nci.evs.api.model.Concept;
 import gov.nih.nci.evs.api.model.ConceptMinimal;
 import gov.nih.nci.evs.api.model.ConceptNode;
 import gov.nih.nci.evs.api.model.DisjointWith;
-import gov.nih.nci.evs.api.model.HierarchyNode;
 import gov.nih.nci.evs.api.model.IncludeParam;
 import gov.nih.nci.evs.api.model.Path;
 import gov.nih.nci.evs.api.model.Paths;
@@ -1781,103 +1780,9 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
 
   /* see superclass */
   @Override
-  public List<HierarchyNode> getRootNodes(Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException {
-    return self.getHierarchyUtils(terminology).getRootNodes();
-  }
-
-  /**
-   * Returns the child nodes.
-   *
-   * @param parent the parent
-   * @param terminology the terminology
-   * @return the child nodes
-   * @throws JsonParseException the json parse exception
-   * @throws JsonMappingException the json mapping exception
-   * @throws IOException Signals that an I/O exception has occurred.
-   */
-  @Override
-  public List<HierarchyNode> getChildNodes(String parent, Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException {
-    return self.getHierarchyUtils(terminology).getChildNodes(parent, 0);
-  }
-
-  /* see superclass */
-  @Override
-  public List<HierarchyNode> getChildNodes(String parent, int maxLevel, Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException {
-    return self.getHierarchyUtils(terminology).getChildNodes(parent, maxLevel);
-  }
-
-  /* see superclass */
-  @Override
   public List<String> getAllChildNodes(String parent, Terminology terminology)
     throws JsonParseException, JsonMappingException, IOException {
     return self.getHierarchyUtils(terminology).getAllChildNodes(parent);
-  }
-
-  /* see superclass */
-  @Override
-  public void checkPathInHierarchy(String code, HierarchyNode node, Path path,
-    Terminology terminology) throws JsonParseException, JsonMappingException, IOException {
-
-    // check for empty path
-    if (path.getConcepts().size() == 0) {
-      return;
-    }
-
-    // get path length
-    int end = path.getConcepts().size() - 1;
-
-    // find the end (in this case top) of the path
-    ConceptNode concept = path.getConcepts().get(end);
-    List<HierarchyNode> children = getChildNodes(node.getCode(), 1, terminology);
-
-    // attach children to node if necessary
-    if (node.getChildren().size() == 0) {
-      node.setChildren(children);
-    }
-
-    // is this the top level node containing the term in question
-    if (concept.getCode().equals(node.getCode())) {
-
-      // is this the term itself
-      if (node.getCode().equals(code)) {
-        node.setHighlight(true);
-        return;
-      }
-      node.setExpanded(true);
-      if (path.getConcepts() != null && !path.getConcepts().isEmpty()) {
-        path.getConcepts().remove(path.getConcepts().size() - 1);
-      }
-
-      // recursively check its children until we find the term
-      for (HierarchyNode childNode : node.getChildren()) {
-        checkPathInHierarchy(code, childNode, path, terminology);
-      }
-    }
-
-    // this node does not contain the term
-    else {
-      node.setChildren(null); // we don't care about its children
-    }
-
-  }
-
-  /* see superclass */
-  @Override
-  public List<HierarchyNode> getPathInHierarchy(String code, Terminology terminology)
-    throws JsonParseException, JsonMappingException, IOException {
-    List<HierarchyNode> rootNodes = getRootNodes(terminology);
-    Paths paths = getPathToRoot(code, terminology);
-
-    for (HierarchyNode rootNode : rootNodes) {
-      for (Path path : paths.getPaths()) {
-        checkPathInHierarchy(code, rootNode, path, terminology);
-      }
-    }
-
-    return rootNodes;
   }
 
   /* see superclass */

--- a/src/main/java/gov/nih/nci/evs/api/util/ConceptUtils.java
+++ b/src/main/java/gov/nih/nci/evs/api/util/ConceptUtils.java
@@ -18,7 +18,6 @@ import gov.nih.nci.evs.api.model.Concept;
 import gov.nih.nci.evs.api.model.ConceptNode;
 import gov.nih.nci.evs.api.model.ConceptPath;
 import gov.nih.nci.evs.api.model.Definition;
-import gov.nih.nci.evs.api.model.HierarchyNode;
 import gov.nih.nci.evs.api.model.IncludeParam;
 import gov.nih.nci.evs.api.model.Path;
 import gov.nih.nci.evs.api.model.Paths;
@@ -200,48 +199,6 @@ public final class ConceptUtils {
         final Integer level = concept.getLevel();
         final Boolean leaf = concept.getLeaf();
         concept.populateFrom(service.getConcept(concept.getCode(), terminology, ip));
-        concept.setLevel(level);
-        concept.setLeaf(leaf);
-      }
-    }
-    return concepts;
-  }
-
-  /**
-   * Convert concepts from hierarchy.
-   *
-   * @param list the list
-   * @return the list
-   */
-  public static List<Concept> convertConceptsFromHierarchy(final List<HierarchyNode> list) {
-    if (list == null || list.isEmpty()) {
-      return new ArrayList<>();
-    }
-    return list.stream().map(ea -> new Concept(ea)).collect(Collectors.toList());
-  }
-
-  /**
-   * Convert concepts from hierarchy with include.
-   *
-   * @param service the elastic query service
-   * @param ip the ip
-   * @param terminology the terminology
-   * @param list the list
-   * @return the list
-   * @throws Exception the exception
-   */
-  public static List<Concept> convertConceptsFromHierarchyWithInclude(
-    final ElasticQueryService service, final IncludeParam ip, final Terminology terminology,
-    final List<HierarchyNode> list) throws Exception {
-
-    final List<Concept> concepts = convertConceptsFromHierarchy(list);
-    final List<String> codes = concepts.stream().map(c -> c.getCode()).collect(Collectors.toList());
-    final Map<String, Concept> conceptMap = service.getConceptsAsMap(codes, terminology, ip);
-    if (ip.hasAnyTrue()) {
-      for (final Concept concept : concepts) {
-        final Integer level = concept.getLevel();
-        final Boolean leaf = concept.getLeaf();
-        concept.populateFrom(conceptMap.get(concept.getCode()));
         concept.setLevel(level);
         concept.setLeaf(leaf);
       }

--- a/src/main/java/gov/nih/nci/evs/api/util/HierarchyUtils.java
+++ b/src/main/java/gov/nih/nci/evs/api/util/HierarchyUtils.java
@@ -18,8 +18,6 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
 import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.HierarchyNode;
-import gov.nih.nci.evs.api.model.Terminology;
 
 /**
  * Hierarchy utilities.
@@ -272,83 +270,6 @@ public class HierarchyUtils {
   /*
    * This section to support the Hierarchy Browser
    */
-
-  /**
-   * Returns the root nodes.
-   *
-   * @return the root nodes
-   */
-  public ArrayList<HierarchyNode> getRootNodes() {
-    ArrayList<HierarchyNode> nodes = new ArrayList<HierarchyNode>();
-    for (String code : this.hierarchyRoots) {
-      HierarchyNode node = new HierarchyNode(code, code2label.get(code), false);
-      nodes.add(node);
-    }
-    nodes.sort(Comparator.comparing(HierarchyNode::getLabel));
-    return nodes;
-  }
-
-  /**
-   * Returns the child nodes.
-   *
-   * @param parent the parent
-   * @param maxLevel the max level
-   * @return the child nodes
-   */
-  public ArrayList<HierarchyNode> getChildNodes(String parent, int maxLevel) {
-    ArrayList<HierarchyNode> nodes = new ArrayList<HierarchyNode>();
-    ArrayList<String> children = this.parent2child.get(parent);
-    if (children == null) {
-      return nodes;
-    }
-    for (String code : children) {
-      HierarchyNode node = new HierarchyNode(code, code2label.get(code), false);
-      getChildNodesLevel(node, maxLevel, 0);
-      nodes.add(node);
-    }
-    nodes.sort(Comparator.comparing(HierarchyNode::getLabel));
-    return nodes;
-  }
-
-  /**
-   * Returns the child nodes level.
-   *
-   * @param node the node
-   * @param maxLevel the max level
-   * @param level the level
-   * @return the child nodes level
-   */
-  public void getChildNodesLevel(HierarchyNode node, int maxLevel, int level) {
-    List<String> children = this.parent2child.get(node.getCode());
-    node.setLevel(level);
-
-    if (children == null || children.size() == 0) {
-      node.setLeaf(true);
-      return;
-    } else {
-      node.setLeaf(false);
-    }
-    if (level >= maxLevel) {
-      return;
-    }
-
-    ArrayList<HierarchyNode> nodes = new ArrayList<HierarchyNode>();
-    level = level + 1;
-    for (String code : children) {
-      HierarchyNode newnode = new HierarchyNode(code, code2label.get(code), false);
-      getChildNodesLevel(newnode, maxLevel, level);
-      List<HierarchyNode> sortedChildren = newnode.getChildren();
-      // Sort children if they exist
-      if (sortedChildren != null && sortedChildren.size() > 0) {
-        sortedChildren.sort(Comparator.comparing(HierarchyNode::getLabel));
-      }
-
-      newnode.setChildren(sortedChildren);
-      nodes.add(newnode);
-    }
-    nodes.sort(Comparator.comparing(HierarchyNode::getLabel));
-    node.setChildren(nodes);
-  }
 
   /**
    * Returns the all child nodes recursive.

--- a/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
@@ -691,7 +691,6 @@ public class ConceptControllerTests {
     });
     log.info("  list = " + list.size());
     assertThat(list).isNotEmpty();
-    assertThat(list.get(0).getSynonyms()).isNotEmpty();
   }
 
   /**


### PR DESCRIPTION
1. Get rid of HierarchyNode where possible. Still using in subtree and subtree/children

2. Remove functions deprecated by this change

3. remove a HierarchyNode helper function that didn't really serve a purpose

There might still be another commit or two for any cleanup that's necessary but this is the meat and potatoes of it.