### PR TITLE
improving search precision

### DIFF
--- a/src/main/java/gov/nih/nci/evs/api/configuration/EVSElasticsearchRestTemplate.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/EVSElasticsearchRestTemplate.java
@@ -1,0 +1,37 @@
+package gov.nih.nci.evs.api.configuration;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.core.SearchResultMapper;
+import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
+import org.springframework.data.elasticsearch.core.query.SearchQuery;
+
+/**
+ * Custom {@link ElasticsearchRestTemplate} to log queries.
+ * 
+ * As of spring-data-elasticsearch version 3.2.0, only one query method logs query and honors 
+ * spring data logging property. This custom implementation is to cover for that gap.
+ * 
+ * @author Arun
+ *
+ */
+public class EVSElasticsearchRestTemplate extends ElasticsearchRestTemplate {
+
+  private static final Logger logger = LoggerFactory.getLogger(EVSElasticsearchRestTemplate.class);
+  
+  public EVSElasticsearchRestTemplate(RestHighLevelClient client) {
+    super(client);
+  }
+  
+  @Override
+  public <T> AggregatedPage<T> queryForPage(SearchQuery query, Class<T> clazz, SearchResultMapper mapper) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("doSearch query:\n" + query.getQuery().toString());
+    }    
+    
+    return super.queryForPage(query, clazz, mapper);
+  }
+  
+}

--- a/src/main/java/gov/nih/nci/evs/api/configuration/ElasticConfiguration.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/ElasticConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 
 @Configuration
 public class ElasticConfiguration {
@@ -30,5 +31,10 @@ public class ElasticConfiguration {
     // ClientConfiguration clientConfiguration =
     // ClientConfiguration.builder().connectedTo(esHost)..build();
     // return RestClients.create(clientConfiguration).rest();
+  }
+  
+  @Bean(name = "elasticsearchTemplate")
+  ElasticsearchRestTemplate elasticRestTemplate() {
+    return new EVSElasticsearchRestTemplate(client());
   }
 }

--- a/src/main/java/gov/nih/nci/evs/api/service/ElasticSearchServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/ElasticSearchServiceImpl.java
@@ -83,12 +83,15 @@ public class ElasticSearchServiceImpl implements ElasticSearchService {
     queryStringQueryBuilder = queryStringQueryBuilder.type(Type.BEST_FIELDS);
 
     // prepare bool query
-    BoolQueryBuilder boolQuery = new BoolQueryBuilder().should(queryStringQueryBuilder.boost(10f))
-        .should(QueryBuilders.nestedQuery("properties", queryStringQueryBuilder, ScoreMode.Total)
+    BoolQueryBuilder boolQuery = new BoolQueryBuilder()
+        .should(QueryBuilders.queryStringQuery(queryStringQueryBuilder.queryString())
+            .field("name", 2f)
+            .boost(10f))
+        .should(QueryBuilders.nestedQuery("properties", queryStringQueryBuilder, ScoreMode.Max)
             .boost(2f))
-        .should(QueryBuilders.nestedQuery("definitions", queryStringQueryBuilder, ScoreMode.Total)
+        .should(QueryBuilders.nestedQuery("definitions", queryStringQueryBuilder, ScoreMode.Max)
             .boost(4f))
-        .should(QueryBuilders.nestedQuery("synonyms", queryStringQueryBuilder, ScoreMode.Total)
+        .should(QueryBuilders.nestedQuery("synonyms", queryStringQueryBuilder, ScoreMode.Max)
             .boost(8f));
 
     // append terminology query

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,7 +34,8 @@ logging:
     level:
         org.springframework: WARN
         gov.nih.nci.evs.api: INFO
-        org.springframework.data.elasticsearch.core: INFO
+        org.springframework.data.elasticsearch.core: DEBUG
+        gov.nih.nci.evs.api.configuration.EVSElasticsearchRestTemplate: DEBUG
 
 #
 # Server Properties

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,7 @@ logging:
         org.springframework: ${LOGGING_LEVEL_ORG_SPRINGFRAMEWORK:WARN}
         gov.nih.nci.evs.api: ${LOGGING_LEVEL_GOV_NIH_NCI_EVS_API:INFO}
         org.springframework.data.elasticsearch.core: ${LOGGING_LEVEL_SPRING_DATA_ES:INFO}
+        gov.nih.nci.evs.api.configuration.EVSElasticsearchRestTemplate: ${LOGGING_LEVEL_SPRING_DATA_ES:INFO}
 
 #
 # Server Properties


### PR DESCRIPTION
Includes:
- query logging: elasticsearch honors the query logging property for only some of the query methods, therefore using custom ElasticsearchRestTemplate to log query being sent to elasticsearch

- boosting name field matches: boosting name field matches seems to move exact matching documents to the top