### PR TITLE
RDFBROWSER-118: definition/synonym sources calls only return those attached to non-retired concepts.

### DIFF
--- a/src/main/java/gov/nih/nci/evs/api/model/TerminologyMetadata.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/TerminologyMetadata.java
@@ -22,6 +22,9 @@ public class TerminologyMetadata extends BaseModel {
   /** The concept status. */
   private String conceptStatus;
 
+  /** The retired status value. */
+  private String retiredStatusValue;
+
   /** The preferred name. */
   private String preferredName;
 
@@ -79,7 +82,7 @@ public class TerminologyMetadata extends BaseModel {
   /** The sources to remove. */
   private Set<String> sourcesToRemove;
 
-  /** The subsetMembers for association entries */
+  /** The subsetMembers for association entries. */
   private Set<String> subsetMember;
 
   /**
@@ -106,6 +109,7 @@ public class TerminologyMetadata extends BaseModel {
   public void populateFrom(final TerminologyMetadata other) {
     code = other.getCode();
     conceptStatus = other.getConceptStatus();
+    retiredStatusValue = other.getRetiredStatusValue();
     definitionSource = other.getDefinitionSource();
     definition = new HashSet<>(other.getDefinition());
     mapRelation = other.getMapRelation();
@@ -305,6 +309,24 @@ public class TerminologyMetadata extends BaseModel {
    */
   public void setConceptStatus(String conceptStatus) {
     this.conceptStatus = conceptStatus;
+  }
+
+  /**
+   * Returns the retired status value.
+   *
+   * @return the retired status value
+   */
+  public String getRetiredStatusValue() {
+    return retiredStatusValue;
+  }
+
+  /**
+   * Sets the retired status value.
+   *
+   * @param retiredStatusValue the retired status value
+   */
+  public void setRetiredStatusValue(String retiredStatusValue) {
+    this.retiredStatusValue = retiredStatusValue;
   }
 
   /**
@@ -660,6 +682,8 @@ public class TerminologyMetadata extends BaseModel {
   }
 
   /**
+   * Returns the subset member.
+   *
    * @return the subsetMember
    */
   public Set<String> getSubsetMember() {
@@ -670,6 +694,8 @@ public class TerminologyMetadata extends BaseModel {
   }
 
   /**
+   * Sets the subset member.
+   *
    * @param subsetMember the subsetMember to set
    */
   public void setSubsetMember(Set<String> subsetMember) {

--- a/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderServiceImpl.java
@@ -126,7 +126,8 @@ public class QueryBuilderServiceImpl implements QueryBuilderService {
       }
     }
     String query = getResolvedProperty(queryProp, values);
-    // log.debug("construct " + queryProp + " - " + query);
+    log.debug("construct " + queryProp + " - " + query);
+    log.debug("construct map " + values);
     return query;
   }
 

--- a/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderServiceImpl.java
@@ -126,8 +126,8 @@ public class QueryBuilderServiceImpl implements QueryBuilderService {
       }
     }
     String query = getResolvedProperty(queryProp, values);
-    log.debug("construct " + queryProp + " - " + query);
-    log.debug("construct map " + values);
+    // log.debug("construct " + queryProp + " - " + query);
+    // log.debug("construct map " + values);
     return query;
   }
 

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -1735,7 +1735,7 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
         log.debug("    trimmed = "
             + path.getConcepts().stream().map(c -> c.getCode()).collect(Collectors.toList()));
       }
-     
+
       // Save the trimmed paths (this is where mma comes from)
       map.put(code, trimmedPaths);
     }

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -2273,8 +2273,12 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
   public List<ConceptMinimal> getSynonymSources(Terminology terminology)
     throws JsonMappingException, JsonProcessingException, IOException {
     String queryPrefix = queryBuilderService.contructPrefix(terminology.getSource());
+
     String query = queryBuilderService.constructQuery("axiom.qualifier.values",
-        terminology.getMetadata().getSynonymSource(), terminology.getGraph());
+        ConceptUtils.asMap("namedGraph", terminology.getGraph(), "conceptCode",
+            terminology.getMetadata().getSynonymSource(), "conceptStatusCode",
+            terminology.getMetadata().getConceptStatus(), "retiredStatusValue",
+            terminology.getMetadata().getRetiredStatusValue()));
     String res = restUtils.runSPARQL(queryPrefix + query, getQueryURL());
 
     ObjectMapper mapper = new ObjectMapper();
@@ -2307,7 +2311,10 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
     throws JsonMappingException, JsonProcessingException, IOException {
     String queryPrefix = queryBuilderService.contructPrefix(terminology.getSource());
     String query = queryBuilderService.constructQuery("axiom.qualifier.values",
-        terminology.getMetadata().getSynonymTermType(), terminology.getGraph());
+        ConceptUtils.asMap("namedGraph", terminology.getGraph(), "conceptCode",
+            terminology.getMetadata().getSynonymTermType(), "conceptStatusCode",
+            terminology.getMetadata().getConceptStatus(), "retiredStatusValue",
+            terminology.getMetadata().getRetiredStatusValue()));
     String res = restUtils.runSPARQL(queryPrefix + query, getQueryURL());
 
     ObjectMapper mapper = new ObjectMapper();
@@ -2340,7 +2347,11 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
     throws JsonMappingException, JsonProcessingException, IOException {
     String queryPrefix = queryBuilderService.contructPrefix(terminology.getSource());
     String query = queryBuilderService.constructQuery("axiom.qualifier.values",
-        terminology.getMetadata().getDefinitionSource(), terminology.getGraph());
+        ConceptUtils.asMap("namedGraph", terminology.getGraph(), "conceptCode",
+            terminology.getMetadata().getDefinitionSource(), "conceptStatusCode",
+            terminology.getMetadata().getConceptStatus(), "retiredStatusValue",
+            terminology.getMetadata().getRetiredStatusValue()));
+    log.info("XXX = " + query);
     String res = restUtils.runSPARQL(queryPrefix + query, getQueryURL());
 
     ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -2351,7 +2351,6 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
             terminology.getMetadata().getDefinitionSource(), "conceptStatusCode",
             terminology.getMetadata().getConceptStatus(), "retiredStatusValue",
             terminology.getMetadata().getRetiredStatusValue()));
-    log.info("XXX = " + query);
     String res = restUtils.runSPARQL(queryPrefix + query, getQueryURL());
 
     ObjectMapper mapper = new ObjectMapper();

--- a/src/main/resources/metadata/ncit.json
+++ b/src/main/resources/metadata/ncit.json
@@ -1,6 +1,7 @@
 {
   "code": "NHC0",
   "conceptStatus": "P310",
+  "retiredStatusValue": "Retired_Concept",
   "preferredName": "P108",
   "synonym": [ "P90", "P107", "P108" ],
   "synonymTermType": "P383",

--- a/src/main/resources/sparql-queries.properties
+++ b/src/main/resources/sparql-queries.properties
@@ -736,7 +736,7 @@ axiom.qualifier.values=SELECT DISTINCT ?propertyValue \
     ?c a owl:Class . \
     ?a owl:annotatedSource ?c . \
     ?a :#{conceptCode} ?propertyValue . \
-    filter not exists { ?c :P310 "Retired_Concept" } \
+    filter not exists { ?c :#{conceptStatusCode} "#{retiredStatusValue}" } \
   } \
 } \
 ORDER BY ?propertyValue

--- a/src/main/resources/sparql-queries.properties
+++ b/src/main/resources/sparql-queries.properties
@@ -1,10 +1,13 @@
-# constructClassCountsQuery(String namedGraph)
-# @deprecated
-class.counts=SELECT ( count(?class) as ?count ) {  \
-    GRAPH <#{namedGraph}> {  \
-        ?class a owl:Class  \
-  } \
-}
+# contructPrefix(String source)
+prefix.graph=PREFIX :<#{source}#> \
+PREFIX base:<#{source}>
+
+prefix.common=PREFIX owl:<http://www.w3.org/2002/07/owl#> \
+PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#> \
+PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#> \
+PREFIX xsd:<http://www.w3.org/2001/XMLSchema#> \
+PREFIX dc:<http://purl.org/dc/elements/1.1/> \
+PREFIX xml:<http://www.w3.org/2001/XMLSchema#> 
 
 # constructAllGraphNamesQuery()
 all.graph.names=select distinct ?graphName where { graph ?graphName {?s ?p ?o} }
@@ -668,6 +671,7 @@ all.properties=SELECT ?property ?propertyCode  ?propertyLabel ?propertyValue \
 ORDER BY ?propertyLabel
 
 # distinct property values (String properytCode, String namedGraph)
+# for all concepts, regardless of status
 distinct.property.values=SELECT DISTINCT ?propertyValue \
 { GRAPH <#{namedGraph}> \
   { ?c a owl:Class . \
@@ -724,33 +728,32 @@ all.roles=SELECT ?property ?propertyCode ?propertyLabel ?propertyValue \
 ORDER BY ?propertyLabel
 
 # find all property values used for the specified axiom qualifier
+# except those values used on retired concepts
 axiom.qualifier.values=SELECT DISTINCT ?propertyValue \
 { GRAPH <#{namedGraph}> \
-  { ?axiom a owl:Axiom . \
-    { ?axiom :#{conceptCode} ?propertyValue } \
+  { \
+    ?a a owl:Axiom . \
+    ?c a owl:Class . \
+    ?a owl:annotatedSource ?c . \
+    ?a :#{conceptCode} ?propertyValue . \
+    filter not exists { ?c :P310 "Retired_Concept" } \
   } \
 } \
 ORDER BY ?propertyValue
 
-# concept property values
-concept.property.values=SELECT DISTINCT ?propertyValue \
+# find all property values used for the specified axiom qualifier
+# only on retired concepts
+axiom.qualifier.retired.values=SELECT DISTINCT ?propertyValue \
 { GRAPH <#{namedGraph}> \
-  { ?class a owl:Class . \
-    { ?class :#{conceptCode} ?propertyValue } \
+  { \
+    ?a a owl:Axiom . \
+    ?c a owl:Class . \
+    ?c :P310 "Retired_Concept" . \
+    ?a owl:annotatedSource ?c . \
+    ?a :#{conceptCode} ?propertyValue \
   } \
 } \
 ORDER BY ?propertyValue
-
-# contructPrefix(String source)
-prefix.graph=PREFIX :<#{source}#> \
-PREFIX base:<#{source}>
-
-prefix.common=PREFIX owl:<http://www.w3.org/2002/07/owl#> \
-PREFIX rdf:<http://www.w3.org/1999/02/22-rdf-syntax-ns#> \
-PREFIX rdfs:<http://www.w3.org/2000/01/rdf-schema#> \
-PREFIX xsd:<http://www.w3.org/2001/XMLSchema#> \
-PREFIX dc:<http://purl.org/dc/elements/1.1/> \
-PREFIX xml:<http://www.w3.org/2001/XMLSchema#> 
 
 # batch queries
 

--- a/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerExtensionTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerExtensionTests.java
@@ -31,7 +31,7 @@ import gov.nih.nci.evs.api.model.Concept;
 import gov.nih.nci.evs.api.properties.TestProperties;
 
 /**
- * Integration tests for MetadataController.
+ * Integration tests for ConceptController around "extensions".
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerIncludeTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerIncludeTests.java
@@ -25,7 +25,7 @@ import gov.nih.nci.evs.api.model.Concept;
 import gov.nih.nci.evs.api.properties.TestProperties;
 
 /**
- * Integration tests for MetadataController.
+ * Integration tests for ConceptController for "include" flag.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
@@ -42,7 +42,7 @@ import gov.nih.nci.evs.api.model.Synonym;
 import gov.nih.nci.evs.api.properties.TestProperties;
 
 /**
- * Integration tests for MetadataController.
+ * Integration tests for ConceptController.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/nih/nci/evs/api/controller/DocumentationPayloadExamplesTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/DocumentationPayloadExamplesTests.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.nih.nci.evs.api.properties.TestProperties;
 
 /**
- * Integration tests for MetadataController.
+ * Integration tests for generating documentation payload examples.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/nih/nci/evs/api/controller/MetadataControllerIncludeTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/MetadataControllerIncludeTests.java
@@ -25,7 +25,7 @@ import gov.nih.nci.evs.api.model.Concept;
 import gov.nih.nci.evs.api.properties.TestProperties;
 
 /**
- * Integration tests for MetadataController.
+ * Integration tests for MetadataController for "include" parameter.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/nih/nci/evs/api/controller/NCIMControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/NCIMControllerTests.java
@@ -29,7 +29,7 @@ import gov.nih.nci.evs.api.model.Terminology;
 import gov.nih.nci.evs.api.properties.TestProperties;
 
 /**
- * The Class SearchControllerTests.
+ * Integration tests for NCIm loader.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -34,7 +34,7 @@ import gov.nih.nci.evs.api.model.Synonym;
 import gov.nih.nci.evs.api.properties.TestProperties;
 
 /**
- * The Class SearchControllerTests.
+ * Integration tests for SearchController.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/nih/nci/evs/api/controller/VersionControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/VersionControllerTests.java
@@ -29,7 +29,7 @@ import gov.nih.nci.evs.api.properties.TestProperties;
 import gov.nih.nci.evs.api.support.ApplicationVersion;
 
 /**
- * The Class VersionControllerTests.
+ * Integration tests for VersionController.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/nih/nci/evs/api/service/SparqlQueryManagerImplTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/service/SparqlQueryManagerImplTests.java
@@ -9,8 +9,6 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,7 +28,8 @@ import gov.nih.nci.evs.api.util.TerminologyUtils;
 public class SparqlQueryManagerImplTests {
 
   /** The logger. */
-  private static final Logger log = LoggerFactory.getLogger(SparqlQueryManagerImplTests.class);
+  // private static final Logger logger =
+  // LoggerFactory.getLogger(SparqlQueryManagerImplTests.class);
 
   /** The mvc. */
   // @Autowired

--- a/src/test/java/gov/nih/nci/evs/api/service/SparqlQueryManagerImplTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/service/SparqlQueryManagerImplTests.java
@@ -1,0 +1,80 @@
+
+package gov.nih.nci.evs.api.service;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import gov.nih.nci.evs.api.model.ConceptMinimal;
+import gov.nih.nci.evs.api.model.Terminology;
+import gov.nih.nci.evs.api.util.TerminologyUtils;
+
+/**
+ * Integration tests for SparqlQueryManagerImpl.
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+public class SparqlQueryManagerImplTests {
+
+  /** The logger. */
+  private static final Logger log = LoggerFactory.getLogger(SparqlQueryManagerImplTests.class);
+
+  /** The mvc. */
+  // @Autowired
+  // private MockMvc mvc;
+
+  @Autowired
+  SparqlQueryManagerService service;
+
+  /** The term utils. */
+  @Autowired
+  TerminologyUtils termUtils;
+
+  /**
+   * Sets the up.
+   */
+  @Before
+  public void setUp() {
+    // n/a
+  }
+
+  /**
+   * NCIM terminology basic tests.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testGetDefinitionSources() throws Exception {
+
+    final Terminology term = termUtils.getTerminology("ncit", true);
+    final List<ConceptMinimal> list = service.getDefinitionSources(term);
+    assertTrue(list.stream().filter(c -> c.getCode().equals("BRIDG")).count() > 0);
+    assertFalse(list.stream().filter(c -> c.getCode().equals("MSH2001")).count() > 0);
+  }
+
+  /**
+   * Test get synonym sources.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testGetSynonymSources() throws Exception {
+
+    final Terminology term = termUtils.getTerminology("ncit", true);
+    final List<ConceptMinimal> list = service.getSynonymSources(term);
+    assertTrue(list.stream().filter(c -> c.getCode().equals("BRIDG")).count() > 0);
+  }
+}

--- a/src/test/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImplTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImplTests.java
@@ -25,7 +25,7 @@ import gov.nih.nci.evs.api.util.TerminologyUtils;
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-public class SparqlQueryManagerImplTests {
+public class SparqlQueryManagerServiceImplTests {
 
   /** The logger. */
   // private static final Logger logger =


### PR DESCRIPTION
This solution is very "NCIt" specific - i may make a couple more changes to turn this into config.