### PR TITLE
Adding check for previous term as well

### DIFF
--- a/src/main/bin/reindex.sh
+++ b/src/main/bin/reindex.sh
@@ -202,8 +202,8 @@ for x in `cat /tmp/y.$$.txt`; do
 
     # if previous version and current version match, then skip
     # this is a monthly that's in both NCIT2 and CTRP databases
-    if [[ $cv == $pv ]]; then
-        echo "    SEEN $cv, continue"
+    if [[ $cv == $pv ]] && [[ $term == $pt ]]; then
+        echo "    SEEN $cv for $pt, continue"
         continue
     fi
 


### PR DESCRIPTION
The check for only the version is matching versions from other terminologies as we add more. So adding check for previous term as well