### PR TITLE
EVSRESTAPI-470 java sdk content type fix

### DIFF
--- a/src/main/java/gov/nih/nci/evs/api/controller/SearchController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/SearchController.java
@@ -324,6 +324,7 @@ public class SearchController extends BaseController {
   @RequestMapping(
       method = RequestMethod.GET,
       value = "/concept/{terminology}/search",
+      consumes = "text/plain",
       produces = "application/json")
   public @ResponseBody ConceptResultList searchSingleTerminology(
       @PathVariable(value = "terminology") final String terminology,
@@ -558,6 +559,7 @@ public class SearchController extends BaseController {
   @RequestMapping(
       method = RequestMethod.GET,
       value = "/concept/search",
+      consumes = "text/plain",
       produces = "application/json")
   public @ResponseBody ConceptResultList search(
       @ModelAttribute SearchCriteria searchCriteria,
@@ -857,6 +859,7 @@ public class SearchController extends BaseController {
   @RequestMapping(
       method = RequestMethod.POST,
       value = "/concept/{terminology}/search",
+      consumes = "text/plain",
       produces = "application/json")
   public @ResponseBody ConceptResultList searchSingleTerminologySparql(
       @PathVariable(value = "terminology") final String terminology,
@@ -1033,6 +1036,7 @@ public class SearchController extends BaseController {
   @RequestMapping(
       method = RequestMethod.POST,
       value = "/sparql/{terminology}",
+      consumes = "text/plain",
       produces = "application/json")
   public @ResponseBody MapResultList getSparqlBindings(
       @PathVariable(value = "terminology") final String terminology,

--- a/src/main/java/gov/nih/nci/evs/api/controller/SearchController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/SearchController.java
@@ -324,7 +324,6 @@ public class SearchController extends BaseController {
   @RequestMapping(
       method = RequestMethod.GET,
       value = "/concept/{terminology}/search",
-      consumes = "text/plain",
       produces = "application/json")
   public @ResponseBody ConceptResultList searchSingleTerminology(
       @PathVariable(value = "terminology") final String terminology,
@@ -559,7 +558,6 @@ public class SearchController extends BaseController {
   @RequestMapping(
       method = RequestMethod.GET,
       value = "/concept/search",
-      consumes = "text/plain",
       produces = "application/json")
   public @ResponseBody ConceptResultList search(
       @ModelAttribute SearchCriteria searchCriteria,

--- a/src/main/java/gov/nih/nci/evs/api/model/SearchCriteriaWithoutTerminology.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/SearchCriteriaWithoutTerminology.java
@@ -555,10 +555,10 @@ public class SearchCriteriaWithoutTerminology extends BaseModel {
    * @return true, if successful
    */
   public boolean checkRequiredFields() {
-//    if (term == null && codeList == null) {
-//      return false;
+    //    if (term == null && codeList == null) {
+    //      return false;
     // TODO: Update this section to fix the validation check with search params
-//    }
+    //    }
     return true;
   }
 

--- a/src/main/java/gov/nih/nci/evs/api/model/SearchCriteriaWithoutTerminology.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/SearchCriteriaWithoutTerminology.java
@@ -555,9 +555,10 @@ public class SearchCriteriaWithoutTerminology extends BaseModel {
    * @return true, if successful
    */
   public boolean checkRequiredFields() {
-    if (term == null && codeList == null) {
-      return false;
-    }
+//    if (term == null && codeList == null) {
+//      return false;
+    // TODO: Update this section to fix the validation check with search params
+//    }
     return true;
   }
 

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -3970,7 +3970,10 @@ public class SearchControllerTests {
     // Try null query
     result =
         mvc.perform(
-                MockMvcRequestBuilders.post(url).param("fromRecord", "1").param("pageSize", "0").contentType("text/plain"))
+                MockMvcRequestBuilders.post(url)
+                    .param("fromRecord", "1")
+                    .param("pageSize", "0")
+                    .contentType("text/plain"))
             .andExpect(status().isBadRequest())
             .andReturn();
 

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -3479,6 +3479,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "minimal")
                     .param("type", "contains"))
             .andExpect(status().isOk())
@@ -3514,6 +3515,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "minimal")
                     .param("type", "contains"))
             .andExpect(status().isOk())
@@ -3540,6 +3542,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "minimal")
                     .param("type", "contains"))
             .andExpect(status().isOk())
@@ -3565,6 +3568,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "minimal")
                     .param("type", "contains"))
             .andExpect(status().isOk())
@@ -3590,6 +3594,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "minimal")
                     .param("type", "contains")
                     .param("term", "Theraccine"))
@@ -3618,6 +3623,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "summary")
                     .param("type", "contains")
                     .param("term", "Liver"))
@@ -3655,6 +3661,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "minimal")
                     .param("type", "contains"))
             .andExpect(status().isOk())
@@ -3689,6 +3696,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "minimal")
                     .param("type", "contains"))
             .andExpect(status().isOk())
@@ -3727,6 +3735,7 @@ public class SearchControllerTests {
               mvc.perform(
                       MockMvcRequestBuilders.post(exceptionUrl)
                           .content(exceptionQuery)
+                          .contentType("text/plain")
                           .param("include", "minimal")
                           .param("type", "contains"))
                   .andExpect(status().is5xxServerError())
@@ -3754,6 +3763,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("include", "minimal")
                     .param("type", "contains"))
             .andExpect(status().isOk())
@@ -3857,6 +3867,7 @@ public class SearchControllerTests {
       mvc.perform(
               MockMvcRequestBuilders.post(url)
                   .content(query)
+                  .contentType("text/plain")
                   .param("fromRecord", "0")
                   .param("pageSize", "10"))
           .andExpect(status().isOk())
@@ -3882,6 +3893,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("fromRecord", "0")
                     .param("pageSize", "10"))
             .andExpect(status().isOk())
@@ -3902,6 +3914,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("fromRecord", "1")
                     .param("pageSize", "5"))
             .andExpect(status().isOk())
@@ -3918,6 +3931,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("fromRecord", "6")
                     .param("pageSize", "5"))
             .andExpect(status().isOk())
@@ -3936,6 +3950,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("fromRecord", "1")
                     .param("pageSize", "0"))
             .andExpect(status().isBadRequest())
@@ -3946,6 +3961,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content(query)
+                    .contentType("text/plain")
                     .param("fromRecord", "1")
                     .param("pageSize", "1001"))
             .andExpect(status().isBadRequest())
@@ -3954,7 +3970,7 @@ public class SearchControllerTests {
     // Try null query
     result =
         mvc.perform(
-                MockMvcRequestBuilders.post(url).param("fromRecord", "1").param("pageSize", "0"))
+                MockMvcRequestBuilders.post(url).param("fromRecord", "1").param("pageSize", "0").contentType("text/plain"))
             .andExpect(status().isBadRequest())
             .andReturn();
 
@@ -3963,6 +3979,7 @@ public class SearchControllerTests {
         mvc.perform(
                 MockMvcRequestBuilders.post(url)
                     .content("")
+                    .contentType("text/plain")
                     .param("fromRecord", "1")
                     .param("pageSize", "1001"))
             .andExpect(status().isBadRequest())


### PR DESCRIPTION
Added the content type consumed by the POST api to text/plain. This will now be in the swagger documentation, which will ensure our SDK code generation includes this in the implementation. 
Commented out a validation check that required a term to not be null in the search api. Added a TODO and a Jira ticket was created to fix later. 
Updated Sparql tests to pass content type for search calls. 