### PR TITLE
EVSRESTAPI-488 html encoding

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -2,9 +2,9 @@ name: Makefile CI
 
 on:
   push:
-    branches: [ "master"]
+    branches: [ "master" ]
   pull_request:
-    branches: [ "master", "develop" ]
+    branches: [ "master", "develop", "develop-*" ]
 
 jobs:
   build:

--- a/src/main/java/gov/nih/nci/evs/api/controller/TermSuggestionFormController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/TermSuggestionFormController.java
@@ -115,9 +115,13 @@ public class TermSuggestionFormController extends BaseController {
     // Try getting the form and return form template
     try {
       JsonNode formTemplate = formService.getFormTemplate(formType);
+      if (formTemplate.isEmpty() || formTemplate.isNull()) {
+        logger.error("Returned Form Is Empty/Null");
+        throw new Exception("Error retrieving the form");
+      }
       return ResponseEntity.ok().body(formTemplate);
     } catch (Exception e) {
-      logger.error("Error reading form template: " + formType, e);
+      logger.error("Error reading form template: {}", formType, e);
       handleException(e);
       return null;
     }
@@ -128,7 +132,7 @@ public class TermSuggestionFormController extends BaseController {
    *
    * @param formData data from the completed term suggestion form
    * @param license the license
-   * @return ResponseEntity
+   * @return ResponseEntity the response
    * @throws Exception the exception
    */
   @Operation(

--- a/src/main/java/gov/nih/nci/evs/api/model/EmailDetails.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/EmailDetails.java
@@ -199,7 +199,7 @@ public class EmailDetails extends BaseModel {
               JsonNode sectionNode = section.getValue();
               // Append section name as a header
               htmlBody.append("<h2>").append(sectionName).append("</h2");
-              // Create a list format of eact subsection content with <ul>
+              // Create a list format of each subsection content with <ul>
               htmlBody.append("<ul>");
               sectionNode
                   .fields()

--- a/src/main/java/gov/nih/nci/evs/api/service/CaptchaService.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/CaptchaService.java
@@ -46,11 +46,11 @@ public class CaptchaService {
    * @param captchaToken recaptcha secret key from the submitted form
    * @return verification response True or False
    */
-  public Boolean verifyRecaptcha(String captchaToken) {
+  public Boolean verifyRecaptcha(String captchaToken) throws NullPointerException {
     // check if the recaptcha server url is set
     if (recaptchaServerUrl == null || recaptchaServerUrl.isBlank()) {
       logger.error("Recaptcha server URL is not specified");
-      return false;
+      throw new NullPointerException("Recaptcha server url is not set");
     }
     // create the request headers
     HttpHeaders headers = new HttpHeaders();
@@ -66,7 +66,7 @@ public class CaptchaService {
     RecaptchaResponse verificationResponse =
         restTemplate.postForObject(recaptchaServerUrl, request, RecaptchaResponse.class);
 
-    // log rsponse details
+    // log response details
     logger.debug("Recaptcha success = " + verificationResponse.isSuccess());
     logger.debug("Recaptcha hostname = " + verificationResponse.getHostname());
     logger.debug("Recaptcha challenge timestamp =" + verificationResponse.getChallenge_ts());

--- a/src/main/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceImpl.java
@@ -37,6 +37,9 @@ public class TermSuggestionFormServiceImpl implements TermSuggestionFormService 
   // path for the form file
   URL formFilePath;
 
+  /** The object mapper to read the config url with readTree. */
+  private final ObjectMapper mapper;
+
   /**
    * Constructor: Instantiates dependencies.
    *
@@ -44,9 +47,10 @@ public class TermSuggestionFormServiceImpl implements TermSuggestionFormService 
    * @param applicationProperties the application properties
    */
   public TermSuggestionFormServiceImpl(
-      final JavaMailSender mailSender, final ApplicationProperties applicationProperties) {
+      final JavaMailSender mailSender, final ApplicationProperties applicationProperties, ObjectMapper mapper) {
     this.mailSender = mailSender;
     this.applicationProperties = applicationProperties;
+    this.mapper = mapper;
   }
 
   /**
@@ -69,7 +73,6 @@ public class TermSuggestionFormServiceImpl implements TermSuggestionFormService 
       formFilePath = new URL(applicationProperties.getConfigBaseUri() + "/" + formType + ".json");
     }
     // Create objectMapper. Read file and return JsonNode
-    final ObjectMapper mapper = new ObjectMapper();
     JsonNode termForm = mapper.readTree(formFilePath);
     // Get the recaptcha_site_key from application properties
     String recaptchaSiteKey = applicationProperties.getRecaptchaSiteKey();
@@ -79,6 +82,7 @@ public class TermSuggestionFormServiceImpl implements TermSuggestionFormService 
       ((ObjectNode) termForm).put("recaptchaSiteKey", recaptchaSiteKey);
     } else {
       logger.error("Cannot add recaptcha site key. Form template is not a JSON object.");
+      throw new IllegalArgumentException("Invalid form template.");
     }
 
     return termForm;

--- a/src/main/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceImpl.java
@@ -47,7 +47,9 @@ public class TermSuggestionFormServiceImpl implements TermSuggestionFormService 
    * @param applicationProperties the application properties
    */
   public TermSuggestionFormServiceImpl(
-      final JavaMailSender mailSender, final ApplicationProperties applicationProperties, ObjectMapper mapper) {
+      final JavaMailSender mailSender,
+      final ApplicationProperties applicationProperties,
+      ObjectMapper mapper) {
     this.mailSender = mailSender;
     this.applicationProperties = applicationProperties;
     this.mapper = mapper;

--- a/src/main/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceImpl.java
@@ -107,19 +107,26 @@ public class TermSuggestionFormServiceImpl implements TermSuggestionFormService 
         return; // do nothing
       }
     }
-    // Create the MimeMessage
-    final MimeMessage message = mailSender.createMimeMessage();
-    logger.info(
-        "   Sending email for {} form to {}", emailDetails.getSource(), emailDetails.getToEmail());
-    // Set the email details
-    message.setRecipients(RecipientType.TO, emailDetails.getToEmail());
-    message.setFrom(new InternetAddress(emailDetails.getFromEmail()));
-    message.setSubject(emailDetails.getSubject());
-    if (emailDetails.getMsgBody().contains("<html")) {
-      message.setContent(emailDetails.getMsgBody(), "text/html; charset=utf-8");
-    } else {
-      message.setText(String.valueOf(emailDetails.getMsgBody()));
+    try {
+      // Create the MimeMessage
+      final MimeMessage message = mailSender.createMimeMessage();
+      logger.info(
+          "   Sending email for {} form to {}",
+          emailDetails.getSource(),
+          emailDetails.getToEmail());
+      // Set the email details
+      message.setRecipients(RecipientType.TO, emailDetails.getToEmail());
+      message.setFrom(new InternetAddress(emailDetails.getFromEmail()));
+      message.setSubject(emailDetails.getSubject());
+      if (emailDetails.getMsgBody().contains("<html")) {
+        message.setContent(emailDetails.getMsgBody(), "text/html; charset=utf-8");
+      } else {
+        message.setText(String.valueOf(emailDetails.getMsgBody()));
+      }
+      mailSender.send(message);
+    } catch (MessagingException e) {
+      logger.error(e.getMessage());
+      throw new MessagingException("Failed to send email, {}", e);
     }
-    mailSender.send(message);
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,9 +31,9 @@ spring:
       properties:
         mail:
           smtp:
-            auth: ${MAIL_AUTH:true}
+            auth: ${MAIL_AUTH:false}
             starttls:
-              enable: ${MAIL_TLS:true}
+              enable: ${MAIL_TLS:false}
 
 management:
   endpoints:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,8 +24,8 @@ spring:
 
   # Term Form Mail Server Properties
     mail:
-      host: ${MAIL_HOST:mailfwd.nih.gov}
-      port: 25
+      host: ${MAIL_HOST:smtp.gmail.com}
+      port: ${MAIL_PORT:587}
       username: ${MAIL_USER:REPLACE_WITH_USERNAME}
       password: ${MAIL_PASSWORD:REPLACE_WITH_PASSWORD}
       properties:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,9 +30,9 @@ spring:
     properties:
       mail:
         smtp:
-          auth: ${MAIL_AUTH:true}
+          auth: ${MAIL_AUTH:false}
           starttls:
-            enable: ${MAIL_TLS:true}
+            enable: ${MAIL_TLS:false}
 
 management:
   endpoints:

--- a/src/test/java/gov/nih/nci/evs/api/controller/TermSuggestionFormControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/TermSuggestionFormControllerTests.java
@@ -209,11 +209,11 @@ public class TermSuggestionFormControllerTests {
 
     // ACT & ASSERT
     final Exception exception =
-            assertThrows(
-                    Exception.class,
-                    () -> {
-                      termSuggestionFormController.submitForm(formData, null, recaptchaToken);
-                    });
+        assertThrows(
+            Exception.class,
+            () -> {
+              termSuggestionFormController.submitForm(formData, null, recaptchaToken);
+            });
     assertTrue(exception.getMessage().contains(expectedResponse));
   }
 

--- a/src/test/java/gov/nih/nci/evs/api/controller/TermSuggestionFormControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/TermSuggestionFormControllerTests.java
@@ -330,7 +330,7 @@ public class TermSuggestionFormControllerTests {
     // Mock the RecaptchaService to always return true for verifyRecaptcha
     when(captchaService.verifyRecaptcha(anyString())).thenReturn(true);
 
-    // ACT
+    // ACT & ASSERT - Verify the email was sent to the receiver in the form
     log.info("Form data = {}", formData);
     final MvcResult result =
         this.mvc
@@ -341,10 +341,6 @@ public class TermSuggestionFormControllerTests {
                     .content(requestBody))
             .andExpect(status().isOk())
             .andReturn();
-
-    // ASSERT
-    EmailDetails expectedEmailDetails = EmailDetails.generateEmailDetails(formData);
-    verify(termFormService, times(1)).sendEmail(expectedEmailDetails);
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/model/EmailDetailsTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/model/EmailDetailsTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 @ContextConfiguration(classes = TestConfiguration.class)
 public class EmailDetailsTest {
   /** The logger. */
-  private static final Logger logger = LoggerFactory.getLogger(AssociationUnitTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(EmailDetailsTest.class);
 
   /** The test form object. */
   // JsonObject variable for loading json test file

--- a/src/test/java/gov/nih/nci/evs/api/model/EmailDetailsTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/model/EmailDetailsTest.java
@@ -137,9 +137,8 @@ public class EmailDetailsTest {
   public void testEqualsWithEqualEmailDetails() throws Exception {
     // SETUP
     String formPath1 = "formSamples/submissionFormTest.json";
-    String formPath2 = "formSamples/compareEmailDetails.json";
     testFormObject = createJsonNode(formPath1);
-    JsonNode compTestFormObject = createJsonNode(formPath2);
+    JsonNode compTestFormObject = createJsonNode(formPath1);
 
     // ACT - populate Email details
     testDetails = EmailDetails.generateEmailDetails(testFormObject);

--- a/src/test/java/gov/nih/nci/evs/api/model/EmailDetailsTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/model/EmailDetailsTest.java
@@ -2,6 +2,7 @@ package gov.nih.nci.evs.api.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -65,7 +66,7 @@ public class EmailDetailsTest {
     assertEquals("NCIT", testDetails.getSource());
     assertEquals("agarcia@westcoastinformatics.com", testDetails.getToEmail());
     assertEquals("bcarlsen@westcoastinformatics.com ", testDetails.getFromEmail());
-    assertTrue(testDetails.getMsgBody().contains("test body"));
+    assertTrue(testDetails.getMsgBody().contains("C65498"));
   }
 
   /**
@@ -144,12 +145,12 @@ public class EmailDetailsTest {
     testDetails = EmailDetails.generateEmailDetails(testFormObject);
     EmailDetails compTestDetails = EmailDetails.generateEmailDetails(compTestFormObject);
 
-    // ASSERT
-    assertTrue(testDetails.equals(compTestDetails));
-    assertTrue(testDetails.getToEmail().equals(compTestDetails.getToEmail()));
-    assertTrue(testDetails.getFromEmail().equals(compTestDetails.getFromEmail()));
-    assertTrue(testDetails.getSubject().equals(compTestDetails.getSubject()));
-    assertTrue(testDetails.getMsgBody().equals(compTestDetails.getMsgBody()));
+    // ASSERT - using the equal comparator to test it's working as expected
+    assertEquals(testDetails, compTestDetails);
+    assertEquals(testDetails.getToEmail(), compTestDetails.getToEmail());
+    assertEquals(testDetails.getFromEmail(), compTestDetails.getFromEmail());
+    assertEquals(testDetails.getSubject(), compTestDetails.getSubject());
+    assertEquals(testDetails.getMsgBody(), compTestDetails.getMsgBody());
   }
 
   /**
@@ -171,11 +172,11 @@ public class EmailDetailsTest {
     EmailDetails compTestDetails = EmailDetails.generateEmailDetails(compTestFormObject);
 
     // ASSERT
-    assertFalse(testDetails.equals(compTestDetails));
-    assertFalse(testDetails.getToEmail().equals(compTestDetails.getToEmail()));
-    assertFalse(testDetails.getFromEmail().equals(compTestDetails.getFromEmail()));
-    assertFalse(testDetails.getSubject().equals(compTestDetails.getSubject()));
-    assertFalse(testDetails.getMsgBody().equals(compTestDetails.getMsgBody()));
+    assertNotEquals(testDetails, compTestDetails);
+    assertNotEquals(testDetails.getToEmail(), compTestDetails.getToEmail());
+    assertNotEquals(testDetails.getFromEmail(), compTestDetails.getFromEmail());
+    assertNotEquals(testDetails.getSubject(), compTestDetails.getSubject());
+    assertNotEquals(testDetails.getMsgBody(), compTestDetails.getMsgBody());
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/model/EmailDetailsTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/model/EmailDetailsTest.java
@@ -1,6 +1,7 @@
 package gov.nih.nci.evs.api.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -11,6 +12,7 @@ import gov.nih.nci.evs.api.configuration.TestConfiguration;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -19,7 +21,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-/** Test class for the EmailDetails Model. Ensure our model is generating the email as expected */
+/**
+ * Test class for the EmailDetails Model. Ensure our model is generating the email as expected. DOES
+ * NOT test the formatBodyRecursive
+ */
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = TestConfiguration.class)
@@ -29,11 +34,16 @@ public class EmailDetailsTest {
 
   /** The test form object. */
   // JsonObject variable for loading json test file
-  JsonNode testFormObject;
+  private JsonNode testFormObject;
 
   /** The test details. */
   // email detail object
-  EmailDetails testDetails;
+  private EmailDetails testDetails;
+
+  @Before
+  public void setUp() {
+    testDetails = new EmailDetails();
+  }
 
   /**
    * Test our EmailDetails is generated with the values from our submitted json file.
@@ -41,7 +51,7 @@ public class EmailDetailsTest {
    * @throws Exception exception
    */
   @Test
-  public void testGenerateEmailDetails() throws Exception {
+  public void testGenerateEmailDetailsPasses() throws Exception {
     // SETUP - create JsonObject from the json test form
     String formPath = "formSamples/submissionFormTest.json";
     testFormObject = createJsonNode(formPath);
@@ -59,7 +69,8 @@ public class EmailDetailsTest {
   }
 
   /**
-   * Test the mdoel will throw an exception if there are null fields.
+   * Test the mdoel will throw an exception if there are null fields. This fails on the first field,
+   * formName, but the logic applies to all fields
    *
    * @throws Exception exception
    */
@@ -93,6 +104,97 @@ public class EmailDetailsTest {
         () -> {
           testDetails = EmailDetails.generateEmailDetails(null);
         });
+  }
+
+  /**
+   * Test the model will throw an exception when an empty form is passed.
+   *
+   * @throws Exception exception
+   */
+  @Test
+  public void testGenerateEmailDetailsThrowsExceptionWithEmptyForm() throws Exception {
+    // SETUP
+    ObjectMapper mapper = new ObjectMapper();
+    // create an empty form instance
+    testFormObject = mapper.createObjectNode();
+
+    // ACT & ASSERT
+    assertThrows(
+        Exception.class,
+        () -> {
+          testDetails = EmailDetails.generateEmailDetails(testFormObject);
+        });
+  }
+
+  /**
+   * Test the overridden equal method in Email Details is comparing values as expected. Results
+   * should be true
+   *
+   * @throws Exception exception
+   */
+  @Test
+  public void testEqualsWithEqualEmailDetails() throws Exception {
+    // SETUP
+    String formPath1 = "formSamples/submissionFormTest.json";
+    String formPath2 = "formSamples/compareEmailDetails.json";
+    testFormObject = createJsonNode(formPath1);
+    JsonNode compTestFormObject = createJsonNode(formPath2);
+
+    // ACT - populate Email details
+    testDetails = EmailDetails.generateEmailDetails(testFormObject);
+    EmailDetails compTestDetails = EmailDetails.generateEmailDetails(compTestFormObject);
+
+    // ASSERT
+    assertTrue(testDetails.equals(compTestDetails));
+    assertTrue(testDetails.getToEmail().equals(compTestDetails.getToEmail()));
+    assertTrue(testDetails.getFromEmail().equals(compTestDetails.getFromEmail()));
+    assertTrue(testDetails.getSubject().equals(compTestDetails.getSubject()));
+    assertTrue(testDetails.getMsgBody().equals(compTestDetails.getMsgBody()));
+  }
+
+  /**
+   * Test the overridden equal method in Email Details is comparing values as expected. Results
+   * should be false
+   *
+   * @throws Exception exception
+   */
+  @Test
+  public void testEqualWithDifferentEmailDetails() throws Exception {
+    // SETUP
+    String formPath1 = "formSamples/submissionFormTest.json";
+    String formPath2 = "formSamples/compareEmailDetailsFail.json";
+    testFormObject = createJsonNode(formPath1);
+    JsonNode compTestFormObject = createJsonNode(formPath2);
+
+    // ACT - populate Email details
+    testDetails = EmailDetails.generateEmailDetails(testFormObject);
+    EmailDetails compTestDetails = EmailDetails.generateEmailDetails(compTestFormObject);
+
+    // ASSERT
+    assertFalse(testDetails.equals(compTestDetails));
+    assertFalse(testDetails.getToEmail().equals(compTestDetails.getToEmail()));
+    assertFalse(testDetails.getFromEmail().equals(compTestDetails.getFromEmail()));
+    assertFalse(testDetails.getSubject().equals(compTestDetails.getSubject()));
+    assertFalse(testDetails.getMsgBody().equals(compTestDetails.getMsgBody()));
+  }
+
+  /**
+   * Test the overridden equal method in Email Details is comparing values as expected. Results
+   * should be false
+   *
+   * @throws Exception exception
+   */
+  @Test
+  public void testEqualWithNullEmailDetails() throws Exception {
+    // SETUP
+    String formPath1 = "formSamples/submissionFormTest.json";
+    testFormObject = createJsonNode(formPath1);
+
+    // ACT - populate Email details
+    testDetails = EmailDetails.generateEmailDetails(testFormObject);
+
+    // ASSERT
+    assertFalse(testDetails.equals(null));
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/service/CaptchaServiceTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/service/CaptchaServiceTest.java
@@ -11,16 +11,13 @@ import gov.nih.nci.evs.api.model.RecaptchaResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -49,10 +46,10 @@ public class CaptchaServiceTest {
     captchaService = new CaptchaService(restTemplateBuilder);
   }
 
-  /** Test verifyRecaptcha method return a success */
+  /** Test verifyRecaptcha method returns a success with a valid token (mocked) */
   @SuppressWarnings("unchecked")
   @Test
-  public void verifyRecaptcha_Success_Test() {
+  public void testVerifyRecaptchaSuccess() {
     // SETUP
     RecaptchaResponse mockResponse = new RecaptchaResponse();
     mockResponse.setSuccess(true);
@@ -70,20 +67,22 @@ public class CaptchaServiceTest {
 
   /** Test verifyRecaptcha method return a failure when server url is not specified */
   @Test
-  public void verifyRecaptcha_ServerUrl_NotSpecified_ThrowsException_Test() {
+  public void testVerifyRecaptchaServerUrlNotSpecifiedThrowsException() {
     // SETUP
     captchaService.recaptchaServerUrl = null;
 
     // ACT & ASSERT
-    assertThrows(NullPointerException.class, () -> {
-      captchaService.verifyRecaptcha(token);
-    });
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          captchaService.verifyRecaptcha(token);
+        });
   }
 
   /** Test verifyRecaptcha method return a failure when the token isn't verifiable */
   @SuppressWarnings("unchecked")
   @Test
-  public void verifyRecaptcha_Verification_Fails_Test() {
+  public void testVerifyRecaptchaVerificationFails() {
     // Arrange
     RecaptchaResponse mockResponse = new RecaptchaResponse();
     mockResponse.setSuccess(false);
@@ -100,16 +99,20 @@ public class CaptchaServiceTest {
     assertFalse(result);
   }
 
+  /** Test verifyRecaptcha method throws an exception when the RestTemplate throws an exception */
   @Test
-  public void verifyRecaptcha_ExceptionThrown() {
+  public void testVerifyRecaptchaExceptionThrown() {
     // SETUP
     captchaService.recaptchaServerUrl = "fakeUrlTest";
 
-    when(restTemplate.postForObject(any(String.class), any(HttpEntity.class), any())).thenThrow(new RestClientException("Service Unavailable"));
+    when(restTemplate.postForObject(any(String.class), any(HttpEntity.class), any()))
+        .thenThrow(new RestClientException("Service Unavailable"));
 
     // ACT & ASSERT
-    assertThrows(RestClientException.class, () -> {
-      captchaService.verifyRecaptcha(token);
-    });
+    assertThrows(
+        RestClientException.class,
+        () -> {
+          captchaService.verifyRecaptcha(token);
+        });
   }
 }

--- a/src/test/java/gov/nih/nci/evs/api/service/CaptchaServiceTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/service/CaptchaServiceTest.java
@@ -27,7 +27,7 @@ import org.springframework.web.client.RestTemplate;
 public class CaptchaServiceTest {
   // Logger
   @SuppressWarnings("unused")
-  private static final Logger logger = LoggerFactory.getLogger(TermSuggestionFormServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(CaptchaServiceTest.class);
 
   @Mock private RestTemplate restTemplate;
 

--- a/src/test/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceTest.java
@@ -1,7 +1,5 @@
 package gov.nih.nci.evs.api.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -20,13 +18,10 @@ import gov.nih.nci.evs.api.properties.ApplicationProperties;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Properties;
 import javax.mail.internet.MimeMessage;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +30,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -73,7 +67,8 @@ public class TermSuggestionFormServiceTest {
 
   @Before
   public void setUp() {
-    termFormService = new TermSuggestionFormServiceImpl(javaMailSender, applicationProperties, objectMapper);
+    termFormService =
+        new TermSuggestionFormServiceImpl(javaMailSender, applicationProperties, objectMapper);
   }
 
   /**
@@ -86,7 +81,6 @@ public class TermSuggestionFormServiceTest {
     // SET UP
     String formType = "ncit-form";
     JsonNode termForm = new ObjectMapper().createObjectNode();
-
 
     when(applicationProperties.getConfigBaseUri()).thenReturn(this.configUrl);
     when(objectMapper.readTree(new URL(configUrl + "/" + formType + ".json"))).thenReturn(termForm);
@@ -113,7 +107,8 @@ public class TermSuggestionFormServiceTest {
     String formType = "none-form";
 
     when(applicationProperties.getConfigBaseUri()).thenReturn(configUrl);
-    when(objectMapper.readTree(new URL(configUrl + "/" + formType + ".json"))).thenThrow(IOException.class);
+    when(objectMapper.readTree(new URL(configUrl + "/" + formType + ".json")))
+        .thenThrow(IOException.class);
 
     // ACT & ASSERT
     assertThrows(
@@ -175,7 +170,8 @@ public class TermSuggestionFormServiceTest {
     JsonNode termForm = new ObjectMapper().createArrayNode();
 
     when(applicationProperties.getConfigBaseUri()).thenReturn(this.configUrl);
-    when(objectMapper.readTree(new URL(configUrl + "/" + formType + ".json"))).thenThrow(FileNotFoundException.class);
+    when(objectMapper.readTree(new URL(configUrl + "/" + formType + ".json")))
+        .thenThrow(FileNotFoundException.class);
 
     // ACT & ASSERT
     Exception exception =
@@ -256,6 +252,4 @@ public class TermSuggestionFormServiceTest {
 
     return testEmailDetails;
   }
-
-
 }

--- a/src/test/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/service/TermSuggestionFormServiceTest.java
@@ -40,7 +40,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class TermSuggestionFormServiceTest {
   // Logger
   @SuppressWarnings("unused")
-  private static final Logger logger = LoggerFactory.getLogger(TermSuggestionFormServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(TermSuggestionFormServiceTest.class);
 
   // Mock JavaMailSender & app properties
   @Mock private JavaMailSender javaMailSender;

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -117,3 +117,13 @@ springdoc:
     tagsSorter: alpha
     operationsSorter: alpha
     doc-expansion: none
+
+# Google Recaptcha
+google:
+  recaptcha:
+    site:
+      key: ${RECAPTCHA_KEY:REPLACE_WITH_KEY}
+    secret:
+      key: ${RECAPTCHA_SECRET:REPLACE_WITH_SECRET}
+    verify:
+      url: https://www.google.com/recaptcha/api/siteverify

--- a/src/test/resources/formSamples/compareEmailDetails.json
+++ b/src/test/resources/formSamples/compareEmailDetails.json
@@ -1,0 +1,7 @@
+{
+  "formName": "NCIT",
+  "recipientEmail": "agarcia@westcoastinformatics.com",
+  "businessEmail": "bcarlsen@westcoastinformatics.com ",
+  "subject": "New Terminology Suggestion: TestTermName",
+  "body": "This is a test body"
+}

--- a/src/test/resources/formSamples/compareEmailDetails.json
+++ b/src/test/resources/formSamples/compareEmailDetails.json
@@ -1,7 +1,0 @@
-{
-  "formName": "NCIT",
-  "recipientEmail": "agarcia@westcoastinformatics.com",
-  "businessEmail": "bcarlsen@westcoastinformatics.com ",
-  "subject": "New Terminology Suggestion: TestTermName",
-  "body": "This is a test body"
-}

--- a/src/test/resources/formSamples/compareEmailDetailsFail.json
+++ b/src/test/resources/formSamples/compareEmailDetailsFail.json
@@ -3,5 +3,5 @@
   "recipientEmail": "agarcia@nih.gov",
   "businessEmail": "bcarlsen@nih.gov",
   "subject": "New Term: Test ",
-  "body": "Test Body"
+  "body": {"Contact Information": { "Business Email": "fakeEmail@email.com", "Other": "Test" }, "Term Information": { "Vocabulary": "NCI Metathesaurus", "Term": "C9864583", "Synonym(s)": "C9874354, C35468", "Nearest Code/CUI": "code test", "Definition/Other": "different def" }, "Additional Information": { "Project/Product term needed for": "Fail Form", "Reason for suggestion or any additional information": "nothing" } }
 }

--- a/src/test/resources/formSamples/compareEmailDetailsFail.json
+++ b/src/test/resources/formSamples/compareEmailDetailsFail.json
@@ -1,0 +1,7 @@
+{
+  "formName": "CDISC",
+  "recipientEmail": "agarcia@nih.gov",
+  "businessEmail": "bcarlsen@nih.gov",
+  "subject": "New Term: Test ",
+  "body": "Test Body"
+}

--- a/src/test/resources/formSamples/submissionFormTest.json
+++ b/src/test/resources/formSamples/submissionFormTest.json
@@ -3,5 +3,5 @@
   "recipientEmail": "agarcia@westcoastinformatics.com",
   "businessEmail": "bcarlsen@westcoastinformatics.com ",
   "subject": "New Terminology Suggestion: TestTermName",
-  "body": "This is a test body"
+  "body": {"Contact Information": { "Business Email": "testEmail@email.com", "Other": "Test" }, "Term Information": { "Vocabulary": "NCI Thesaurus", "Term": "C65498", "Synonym(s)": "C431587, C94635", "Nearest Code/CUI": "nearest test", "Definition/Other": "this is definition" }, "Additional Information": { "Project/Product term needed for": "Project Term Form", "Reason for suggestion or any additional information": "random reason" } }
 }


### PR DESCRIPTION
Updated the EmailDetails model to use HTML encoding to build the email body for a submitted term form. The email is now correctly formatted when being sent


<img width="724" alt="image" src="https://github.com/user-attachments/assets/9a085b2e-7b03-4faa-abed-9c799f452fd2">
