### PR TITLE
quick fix for test fail

### DIFF
--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -3588,7 +3588,7 @@ public class SearchControllerTests {
             + "    ?x a owl:Class .\n"
             + "    ?x :NHC0 ?code .\n"
             + "    ?x :P108 ?label .\n"
-            + "    FILTER(CONTAINS(?label, \"Melanoma\"))\n"
+            + "    FILTER(STRSTARTS(?label, \"Melanoma\"))\n"
             + "  }\n"
             + "}";
     log.info("Testing url - " + url + "?type=contains&include=minimal&term=Theraccine");


### PR DESCRIPTION
fixing a test that failed on devreset. opensearch didn't like how expansive the CONTAINS search result was, so i switched it to a STRSTARTS, which still returns the desired result from the search and the test now passes