### PR TITLE
HOTFIX for JUnit and testing gradle dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,11 +153,11 @@ dependencies {
   */
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
   testImplementation 'org.opensearch.client:spring-data-opensearch-test-autoconfigure:1.5.3'
-  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.3'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
-  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
-  testRuntimeOnly 'org.junit.platform:junit-platform-commons:1.9.3'
-  testRuntimeOnly 'org.junit.platform:junit-platform-runner:1.9.3'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.5'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.5'
+  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.5'
+  testRuntimeOnly 'org.junit.platform:junit-platform-commons:1.10.0'
+  testRuntimeOnly 'org.junit.platform:junit-platform-runner:1.10.0'
   // (avoid using lombok for now)
   //testCompileOnly 'org.projectlombok:lombok:1.18.32'
   //testAnnotationProcessor 'org.projectlombok:lombok:1.18.32'


### PR DESCRIPTION
Updated the versions so they align with what `spring-boot-starter-test` is automatically using.