### PR TITLE
EVSRESTAPI-491: sparql prefixes improvements

### DIFF
--- a/src/main/java/gov/nih/nci/evs/api/controller/SearchController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/SearchController.java
@@ -727,6 +727,12 @@ public class SearchController extends BaseController {
         schema = @Schema(implementation = String.class),
         example = "minimal"),
     @Parameter(
+        name = "prefixes",
+        description = "Use 'true' to use queries with declared prefixes",
+        required = false,
+        schema = @Schema(implementation = Boolean.class),
+        example = "true"),
+    @Parameter(
         name = "fromRecord",
         description = "Start index of the search results",
         required = false,
@@ -865,6 +871,7 @@ public class SearchController extends BaseController {
   public @ResponseBody ConceptResultList searchSingleTerminologySparql(
       @PathVariable(value = "terminology") final String terminology,
       @RequestParam(required = false, name = "include") final Optional<String> include,
+      @RequestParam(required = false, name = "prefixes") final Boolean prefixes,
       @org.springframework.web.bind.annotation.RequestBody final String query,
       @ModelAttribute SearchCriteriaWithoutTerminology searchCriteria,
       BindingResult bindingResult,
@@ -888,7 +895,7 @@ public class SearchController extends BaseController {
     final ObjectMapper mapper = new ObjectMapper();
     try {
 
-      final String sparqlQuery = queryBuilderService.prepSparql(term, query);
+      final String sparqlQuery = queryBuilderService.prepSparql(term, query, prefixes);
       // The following messages up "total" - so we need to either find it another way from
       // the sparql response OR we need to not limit this but do so with paging.
       //      sparqlQuery += " LIMIT 1000";
@@ -1030,6 +1037,12 @@ public class SearchController extends BaseController {
         schema = @Schema(implementation = Integer.class),
         example = "10"),
     @Parameter(
+        name = "prefixes",
+        description = "Use 'true' to use queries with declared prefixes",
+        required = false,
+        schema = @Schema(implementation = Boolean.class),
+        example = "true"),
+    @Parameter(
         name = "X-EVSRESTAPI-License-Key",
         description =
             "Required license information for restricted terminologies. <a"
@@ -1048,6 +1061,7 @@ public class SearchController extends BaseController {
       @PathVariable(value = "terminology") final String terminology,
       @RequestParam(required = false, name = "fromRecord") final Integer fromRecord,
       @RequestParam(required = false, name = "pageSize") final Integer pageSize,
+      @RequestParam(required = false, name = "prefixes") final Boolean prefixes,
       @org.springframework.web.bind.annotation.RequestBody final String query,
       @RequestHeader(name = "X-EVSRESTAPI-License-Key", required = false) final String license)
       throws Exception {
@@ -1077,7 +1091,7 @@ public class SearchController extends BaseController {
       }
 
       final ObjectMapper mapper = new ObjectMapper();
-      String sparqlQuery = queryBuilderService.prepSparql(term, query);
+      String sparqlQuery = queryBuilderService.prepSparql(term, query, prefixes);
 
       // The following messages up "total" - so we need to either find it another way from
       // the sparql response OR we need to not limit this but do so with paging.
@@ -1166,7 +1180,7 @@ public class SearchController extends BaseController {
             HttpStatus.EXPECTATION_FAILED,
             "Terminology is not RDF-based and cannot be queried for sparql");
       }
-      final String prefixes = queryBuilderService.constructPrefix(term);
+      final String prefixes = queryBuilderService.constructPrefix(term).replaceAll("\\r", "");
       return new ResponseEntity<>(
           new ObjectMapper().writeValueAsString(prefixes), new HttpHeaders(), HttpStatus.OK);
 

--- a/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderService.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderService.java
@@ -1,8 +1,9 @@
 package gov.nih.nci.evs.api.service;
 
-import gov.nih.nci.evs.api.model.Terminology;
 import java.util.List;
 import java.util.Map;
+
+import gov.nih.nci.evs.api.model.Terminology;
 
 /** Query builder service. */
 public interface QueryBuilderService {
@@ -11,6 +12,7 @@ public interface QueryBuilderService {
    * Construct graph query.
    *
    * @param queryProp the query prop
+   * @param ignoreSources the ignore sources
    * @return the string
    */
   public String constructGraphQuery(String queryProp, List<String> ignoreSources);
@@ -19,7 +21,7 @@ public interface QueryBuilderService {
    * Construct query.
    *
    * @param queryProp the query prop
-   * @param namedGraph the named graph
+   * @param terminology the terminology
    * @return the string
    */
   public String constructQuery(String queryProp, Terminology terminology);
@@ -28,8 +30,8 @@ public interface QueryBuilderService {
    * Construct query.
    *
    * @param queryProp the query prop
+   * @param terminology the terminology
    * @param conceptCode the concept code
-   * @param namedGraph the named graph
    * @return the string
    */
   public String constructQuery(String queryProp, Terminology terminology, String conceptCode);
@@ -59,7 +61,7 @@ public interface QueryBuilderService {
   /**
    * Contruct prefix.
    *
-   * @param source the graph source
+   * @param terminology the terminology
    * @return the string
    */
   public String constructPrefix(Terminology terminology);
@@ -72,4 +74,15 @@ public interface QueryBuilderService {
    * @return the string
    */
   public String prepSparql(final Terminology terminology, final String query);
+
+  /**
+   * Prep sparql.
+   *
+   * @param terminology the terminology
+   * @param query the query
+   * @param keepPrefixes the prefixes
+   * @return the string
+   */
+  public String prepSparql(
+      final Terminology terminology, final String query, final Boolean keepPrefixes);
 }

--- a/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderService.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderService.java
@@ -1,9 +1,8 @@
 package gov.nih.nci.evs.api.service;
 
+import gov.nih.nci.evs.api.model.Terminology;
 import java.util.List;
 import java.util.Map;
-
-import gov.nih.nci.evs.api.model.Terminology;
 
 /** Query builder service. */
 public interface QueryBuilderService {

--- a/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderServiceImpl.java
@@ -1,11 +1,9 @@
 package gov.nih.nci.evs.api.service;
 
-import gov.nih.nci.evs.api.model.Terminology;
-import gov.nih.nci.evs.api.properties.StardogProperties;
-import gov.nih.nci.evs.api.util.ConceptUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.slf4j.Logger;
@@ -14,6 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
+
+import gov.nih.nci.evs.api.model.Terminology;
+import gov.nih.nci.evs.api.properties.StardogProperties;
+import gov.nih.nci.evs.api.util.ConceptUtils;
 
 /**
  * Reference implementation of {@link QueryBuilderService}. Includes hibernate tags for MEME
@@ -78,15 +80,23 @@ public class QueryBuilderServiceImpl implements QueryBuilderService {
     return prefix;
   }
 
-  /* see superclass */
   @Override
   public String prepSparql(final Terminology terminology, final String query) {
+    return prepSparql(terminology, query, false);
+  }
+
+  /* see superclass */
+  @Override
+  public String prepSparql(
+      final Terminology terminology, final String query, final Boolean keepPrefixes) {
 
     // Replace non space whitespace
     String sparqlQuery = query.replaceAll("[\t\r\n]", "::newline::");
 
     // Replace prefixes
-    sparqlQuery = sparqlQuery.replaceFirst("(?i:.*?SELECT )", "SELECT ");
+    if (keepPrefixes == null || !keepPrefixes) {
+      sparqlQuery = sparqlQuery.replaceFirst("(?i:.*?SELECT )", "SELECT ");
+    }
 
     // Replace graph
     sparqlQuery =
@@ -105,7 +115,10 @@ public class QueryBuilderServiceImpl implements QueryBuilderService {
     }
     sparqlQuery = sparqlQuery.replaceAll("::newline::", "\n");
 
-    return constructPrefix(terminology) + "\n" + sparqlQuery;
+    return ((keepPrefixes == null || !keepPrefixes)
+            ? (constructPrefix(terminology) + "\n")
+            : "")
+        + sparqlQuery;
   }
 
   /**

--- a/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/QueryBuilderServiceImpl.java
@@ -1,9 +1,11 @@
 package gov.nih.nci.evs.api.service;
 
+import gov.nih.nci.evs.api.model.Terminology;
+import gov.nih.nci.evs.api.properties.StardogProperties;
+import gov.nih.nci.evs.api.util.ConceptUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.text.StringSubstitutor;
 import org.slf4j.Logger;
@@ -12,10 +14,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
-
-import gov.nih.nci.evs.api.model.Terminology;
-import gov.nih.nci.evs.api.properties.StardogProperties;
-import gov.nih.nci.evs.api.util.ConceptUtils;
 
 /**
  * Reference implementation of {@link QueryBuilderService}. Includes hibernate tags for MEME
@@ -115,9 +113,7 @@ public class QueryBuilderServiceImpl implements QueryBuilderService {
     }
     sparqlQuery = sparqlQuery.replaceAll("::newline::", "\n");
 
-    return ((keepPrefixes == null || !keepPrefixes)
-            ? (constructPrefix(terminology) + "\n")
-            : "")
+    return ((keepPrefixes == null || !keepPrefixes) ? (constructPrefix(terminology) + "\n") : "")
         + sparqlQuery;
   }
 

--- a/src/main/resources/sparql-queries.properties
+++ b/src/main/resources/sparql-queries.properties
@@ -751,6 +751,8 @@ roles.hierarchy=SELECT DISTINCT ?parent ?parentCode ?parentLabel ?child ?childCo
 }
 
 # ?concept and ?relatedConcept both must have a code
+# If the query below is having a problem completing in stardog, use
+#    roles.all.complex.ncit=SKIP
 roles.all.complex=SELECT ?conceptCode ?conceptLabel ?relationship ?relationshipCode ?relationshipLabel ?relatedConcept ?relatedConceptCode ?relatedConceptLabel \
 { GRAPH <#{namedGraph}> \
   { \

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -4023,7 +4023,7 @@ public class SearchControllerTests {
    * @throws Exception the exception
    */
   @Test
-  public void testSearctAllNcit() throws Exception {
+  public void testSearchAllNcit() throws Exception {
     String url = null;
     MvcResult result = null;
     String content = null;
@@ -4072,13 +4072,13 @@ public class SearchControllerTests {
   }
 
   /**
-   * Test searct all ncit with sort. This is separate from the prior test because we want to verify
+   * Test search all ncit with sort. This is separate from the prior test because we want to verify
    * that both "rank" sort and a fielded sort behave the same way with respect to this paging stuff.
    *
    * @throws Exception the exception
    */
   @Test
-  public void testSearctAllNcitWithSort() throws Exception {
+  public void testSearchAllNcitWithSort() throws Exception {
     String url = null;
     MvcResult result = null;
     String content = null;
@@ -4125,6 +4125,77 @@ public class SearchControllerTests {
     assertThat(codeSet.size()).isEqualTo(codes.size());
     assertThat(total).isEqualTo(codeSet.size());
     assertThat((long) fromRecord).isGreaterThan(total);
+  }
+
+  /**
+   * Test sparql prefixes.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testSparqlPrefixes() throws Exception {
+    MvcResult result = null;
+    String content = null;
+
+    String nciturl = "/api/v1/sparql/ncit/prefixes";
+
+    log.info("Testing url - " + nciturl);
+    // Test a basic term search
+    result = this.mvc.perform(get(nciturl)).andExpect(status().isOk()).andReturn();
+    content = result.getResponse().getContentAsString();
+    assertThat(content).isNotNull();
+    log.info("  ncit prefixes = " + content);
+    assertThat(content).startsWith("\"PREFIX ");
+    assertThat(content).contains(" :<http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#>");
+    assertThat(content).doesNotContain("HGNC.owl");
+
+    String hgncurl = "/api/v1/sparql/hgnc/prefixes";
+
+    log.info("Testing url - " + hgncurl);
+    // Test a basic term search
+    result = this.mvc.perform(get(hgncurl)).andExpect(status().isOk()).andReturn();
+    content = result.getResponse().getContentAsString();
+    assertThat(content).isNotNull();
+    log.info("  hgnc prefixes = " + content);
+    assertThat(content).startsWith("\"PREFIX ");
+    assertThat(content).doesNotContain("Thesaurus.owl");
+    assertThat(content).contains(":<http://ncicb.nci.nih.gov/genenames.org/HGNC.owl#>");
+  }
+
+  /**
+   * Test non rdf with sparql.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testNonRdfWithSparql() throws Exception {
+
+    log.info("Testing url - " + "/api/v1/sparql/ncim");
+    // Test a basic term search
+    this.mvc
+        .perform(
+            MockMvcRequestBuilders.post("/api/v1/sparql/ncim")
+                .content("query not important")
+                .contentType("text/plain"))
+        .andExpect(status().isExpectationFailed())
+        .andReturn();
+
+    log.info("Testing url - " + "/api/v1/sparql/ncim/prefixes");
+    // Test a basic term search
+    this.mvc
+        .perform(get("/api/v1/sparql/ncim/prefixes"))
+        .andExpect(status().isExpectationFailed())
+        .andReturn();
+
+    log.info("Testing url - /api/v1/concept/ncim/search?type=contains&include=minimal");
+    mvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/concept/ncim/search")
+                .content("query not important")
+                .contentType("text/plain")
+                .param("include", "minimal")
+                .param("type", "contains"))
+        .andExpect(status().isExpectationFailed())
+        .andReturn();
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -4200,6 +4200,41 @@ public class SearchControllerTests {
   }
 
   /**
+   * Test sparql with prefixes. We are just looking here that there are no errors.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testSparqlWithPrefixes() throws Exception {
+
+    // Concept sparql
+    final String sparql =
+        """
+            PREFIX xyz:<http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#>
+              PREFIX owl:<http://www.w3.org/2002/07/owl#>
+              SELECT ?code WHERE { ?x a owl:Class . ?x xyz:NHC0 ?code .?x xyz:P108 "Melanoma" }
+        """;
+    mvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/concept/ncit/search")
+                .content(sparql)
+                .contentType("text/plain")
+                .param("include", "minimal")
+                .param("prefixes", "true"))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    // General sparql
+    log.info("Testing url - /api/v1/concept/ncit/search?prefixes=true&include=minimal");
+    mvc.perform(
+            MockMvcRequestBuilders.post("/api/v1/sparql/ncit")
+                .content(sparql)
+                .contentType("text/plain")
+                .param("prefixes", "true"))
+        .andExpect(status().isOk())
+        .andReturn();
+  }
+
+  /**
    * Removes the time taken.
    *
    * @param response the response

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -4159,6 +4159,7 @@ public class SearchControllerTests {
     log.info("  hgnc prefixes = " + content);
     assertThat(content).startsWith("\"PREFIX ");
     assertThat(content).doesNotContain("Thesaurus.owl");
+    assertThat(content).doesNotContain("\r");
     assertThat(content).contains(":<http://ncicb.nci.nih.gov/genenames.org/HGNC.owl#>");
   }
 


### PR DESCRIPTION
This ticket adds an endpoint for returning the prefixes for a particular terminology (as well as tests for that).
It also adds a "prefixes" parameter to the existing calls that take a sparql query and allows the user to set to "true" and then pass queries with prefixes set.  The examples in develop branch of evsrestapi-client-SDK now have (tested) examples of this usage.