### PR TITLE
Pva/evsrestapi trailing slashes tests

### DIFF
--- a/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
@@ -5,8 +5,30 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.util.CollectionUtils;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import gov.nih.nci.evs.api.model.Association;
 import gov.nih.nci.evs.api.model.AssociationEntry;
 import gov.nih.nci.evs.api.model.AssociationEntryResultList;
@@ -22,25 +44,6 @@ import gov.nih.nci.evs.api.model.Terminology;
 import gov.nih.nci.evs.api.properties.ApplicationProperties;
 import gov.nih.nci.evs.api.properties.TestProperties;
 import gov.nih.nci.evs.api.service.SparqlQueryManagerService;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.json.JacksonTester;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.util.CollectionUtils;
 
 /** Integration tests for ConceptController. */
 @ExtendWith(SpringExtension.class)
@@ -77,6 +80,17 @@ public class ConceptControllerTests {
     JacksonTester.initFields(this, objectMapper);
 
     baseUrl = "/api/v1/concept";
+  }
+  
+  @Test
+  /**
+   * test get trailing slash 404
+   * @throws Exception
+   */
+  public void testGetTrailingSlashNcit() throws Exception {
+    String url = baseUrl + "/ncit/C3224/";
+    log.info("Testing url - " + url);
+    mvc.perform(get(url)).andExpect(status().isNotFound()).andReturn();
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
@@ -5,30 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.json.JacksonTester;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.util.CollectionUtils;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import gov.nih.nci.evs.api.model.Association;
 import gov.nih.nci.evs.api.model.AssociationEntry;
 import gov.nih.nci.evs.api.model.AssociationEntryResultList;
@@ -44,6 +22,25 @@ import gov.nih.nci.evs.api.model.Terminology;
 import gov.nih.nci.evs.api.properties.ApplicationProperties;
 import gov.nih.nci.evs.api.properties.TestProperties;
 import gov.nih.nci.evs.api.service.SparqlQueryManagerService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.util.CollectionUtils;
 
 /** Integration tests for ConceptController. */
 @ExtendWith(SpringExtension.class)
@@ -81,10 +78,11 @@ public class ConceptControllerTests {
 
     baseUrl = "/api/v1/concept";
   }
-  
+
   @Test
   /**
    * test get trailing slash 404
+   *
    * @throws Exception
    */
   public void testGetTrailingSlashNcit() throws Exception {

--- a/src/test/java/gov/nih/nci/evs/api/controller/HistoryControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/HistoryControllerTests.java
@@ -5,9 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nih.nci.evs.api.model.History;
+import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,12 +26,6 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.nih.nci.evs.api.model.History;
-import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** subset tests. */
 @ExtendWith(SpringExtension.class)
@@ -60,10 +57,11 @@ public class HistoryControllerTests {
 
     baseUrl = "/api/v1";
   }
-  
+
   @Test
   /**
    * test get trailing slash 404
+   *
    * @throws Exception
    */
   public void testGetTrailingSlashHistory() throws Exception {

--- a/src/test/java/gov/nih/nci/evs/api/controller/HistoryControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/HistoryControllerTests.java
@@ -5,13 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nih.nci.evs.api.model.History;
-import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.Arrays;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
@@ -25,6 +23,12 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.nci.evs.api.model.History;
+import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** subset tests. */
 @ExtendWith(SpringExtension.class)
@@ -55,6 +59,17 @@ public class HistoryControllerTests {
     JacksonTester.initFields(this, objectMapper);
 
     baseUrl = "/api/v1";
+  }
+  
+  @Test
+  /**
+   * test get trailing slash 404
+   * @throws Exception
+   */
+  public void testGetTrailingSlashHistory() throws Exception {
+    String url = baseUrl + "/history/ncit/C4654/replacements/";
+    log.info("Testing url - " + url);
+    mvc.perform(get(url)).andExpect(status().isNotFound()).andReturn();
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/controller/MdrControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/MdrControllerTests.java
@@ -4,15 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.ConceptResultList;
-import gov.nih.nci.evs.api.model.HierarchyNode;
-import gov.nih.nci.evs.api.properties.ApplicationProperties;
-import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +20,15 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.ConceptResultList;
+import gov.nih.nci.evs.api.model.HierarchyNode;
+import gov.nih.nci.evs.api.properties.ApplicationProperties;
+import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** Integration tests for MDR loader. */
 @ExtendWith(SpringExtension.class)
@@ -62,6 +65,17 @@ public class MdrControllerTests {
 
     baseUrl = "/api/v1/concept";
     // baseUrlMetadata = "/api/v1/metadata";
+  }
+  
+  @Test
+  /**
+   * test get trailing slash 404
+   * @throws Exception
+   */
+  public void testGetTrailingSlashMdr() throws Exception {
+    String url = baseUrl + "/mdr/10009802/";
+    log.info("Testing url - " + url);
+    mvc.perform(get(url)).andExpect(status().isNotFound()).andReturn();
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/controller/MdrControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/MdrControllerTests.java
@@ -4,9 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.ConceptResultList;
+import gov.nih.nci.evs.api.model.HierarchyNode;
+import gov.nih.nci.evs.api.properties.ApplicationProperties;
+import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,15 +26,6 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.ConceptResultList;
-import gov.nih.nci.evs.api.model.HierarchyNode;
-import gov.nih.nci.evs.api.properties.ApplicationProperties;
-import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** Integration tests for MDR loader. */
 @ExtendWith(SpringExtension.class)
@@ -66,10 +63,11 @@ public class MdrControllerTests {
     baseUrl = "/api/v1/concept";
     // baseUrlMetadata = "/api/v1/metadata";
   }
-  
+
   @Test
   /**
    * test get trailing slash 404
+   *
    * @throws Exception
    */
   public void testGetTrailingSlashMdr() throws Exception {

--- a/src/test/java/gov/nih/nci/evs/api/controller/MetadataControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/MetadataControllerTests.java
@@ -4,14 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.Property;
-import gov.nih.nci.evs.api.model.StatisticsEntry;
-import gov.nih.nci.evs.api.model.Terminology;
-import gov.nih.nci.evs.api.properties.TestProperties;
-import gov.nih.nci.evs.api.util.ConceptUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +25,16 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.Property;
+import gov.nih.nci.evs.api.model.StatisticsEntry;
+import gov.nih.nci.evs.api.model.Terminology;
+import gov.nih.nci.evs.api.properties.TestProperties;
+import gov.nih.nci.evs.api.util.ConceptUtils;
 
 /** Integration tests for MetadataController. */
 @ExtendWith(SpringExtension.class)
@@ -62,6 +65,17 @@ public class MetadataControllerTests {
     JacksonTester.initFields(this, objectMapper);
 
     baseUrl = "/api/v1/metadata";
+  }
+  
+  @Test
+  /**
+   * test get trailing slash 404
+   * @throws Exception
+   */
+  public void testGetTrailingSlashMetadata() throws Exception {
+    String url = baseUrl + "/terminologies/";
+    log.info("Testing url - " + url);
+    mvc.perform(get(url)).andExpect(status().isNotFound()).andReturn();
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/controller/MetadataControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/MetadataControllerTests.java
@@ -4,6 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.Property;
+import gov.nih.nci.evs.api.model.StatisticsEntry;
+import gov.nih.nci.evs.api.model.Terminology;
+import gov.nih.nci.evs.api.properties.TestProperties;
+import gov.nih.nci.evs.api.util.ConceptUtils;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,16 +32,6 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.Property;
-import gov.nih.nci.evs.api.model.StatisticsEntry;
-import gov.nih.nci.evs.api.model.Terminology;
-import gov.nih.nci.evs.api.properties.TestProperties;
-import gov.nih.nci.evs.api.util.ConceptUtils;
 
 /** Integration tests for MetadataController. */
 @ExtendWith(SpringExtension.class)
@@ -66,10 +63,11 @@ public class MetadataControllerTests {
 
     baseUrl = "/api/v1/metadata";
   }
-  
+
   @Test
   /**
    * test get trailing slash 404
+   *
    * @throws Exception
    */
   public void testGetTrailingSlashMetadata() throws Exception {

--- a/src/test/java/gov/nih/nci/evs/api/controller/NcimControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/NcimControllerTests.java
@@ -4,16 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.ConceptResultList;
-import gov.nih.nci.evs.api.model.HierarchyNode;
-import gov.nih.nci.evs.api.model.Terminology;
-import gov.nih.nci.evs.api.properties.ApplicationProperties;
-import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +20,16 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.ConceptResultList;
+import gov.nih.nci.evs.api.model.HierarchyNode;
+import gov.nih.nci.evs.api.model.Terminology;
+import gov.nih.nci.evs.api.properties.ApplicationProperties;
+import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** Integration tests for NCIm loader. */
 @ExtendWith(SpringExtension.class)
@@ -62,6 +65,17 @@ public class NcimControllerTests {
     JacksonTester.initFields(this, objectMapper);
 
     baseUrl = "/api/v1/concept";
+  }
+  
+  @Test
+  /**
+   * test get trailing slash 404
+   * @throws Exception
+   */
+  public void testGetTrailingSlashNcim() throws Exception {
+    String url = baseUrl + "/ncim/C0000005/";
+    log.info("Testing url - " + url);
+    mvc.perform(get(url)).andExpect(status().isNotFound()).andReturn();
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/controller/NcimControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/NcimControllerTests.java
@@ -4,9 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.ConceptResultList;
+import gov.nih.nci.evs.api.model.HierarchyNode;
+import gov.nih.nci.evs.api.model.Terminology;
+import gov.nih.nci.evs.api.properties.ApplicationProperties;
+import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,16 +27,6 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.ConceptResultList;
-import gov.nih.nci.evs.api.model.HierarchyNode;
-import gov.nih.nci.evs.api.model.Terminology;
-import gov.nih.nci.evs.api.properties.ApplicationProperties;
-import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** Integration tests for NCIm loader. */
 @ExtendWith(SpringExtension.class)
@@ -66,10 +63,11 @@ public class NcimControllerTests {
 
     baseUrl = "/api/v1/concept";
   }
-  
+
   @Test
   /**
    * test get trailing slash 404
+   *
    * @throws Exception
    */
   public void testGetTrailingSlashNcim() throws Exception {

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -7,22 +7,13 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nih.nci.evs.api.model.Association;
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.ConceptResultList;
-import gov.nih.nci.evs.api.model.Definition;
-import gov.nih.nci.evs.api.model.MapResultList;
-import gov.nih.nci.evs.api.model.Property;
-import gov.nih.nci.evs.api.model.Synonym;
-import gov.nih.nci.evs.api.properties.ApplicationProperties;
-import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +28,18 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.nci.evs.api.model.Association;
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.ConceptResultList;
+import gov.nih.nci.evs.api.model.Definition;
+import gov.nih.nci.evs.api.model.MapResultList;
+import gov.nih.nci.evs.api.model.Property;
+import gov.nih.nci.evs.api.model.Synonym;
+import gov.nih.nci.evs.api.properties.ApplicationProperties;
+import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** Integration tests for SearchController. */
 @ExtendWith(SpringExtension.class)
@@ -77,6 +80,17 @@ public class SearchControllerTests {
 
     baseUrl = "/api/v1/concept/search";
     baseUrlNoTerm = "/api/v1/concept";
+  }
+  
+  @Test
+  /**
+   * test get trailing slash 404
+   * @throws Exception
+   */
+  public void testGetTrailingSlashSearch() throws Exception {
+    String url = baseUrl + "/?terminology=ncit&term=melanoma";
+    log.info("Testing url - " + url);
+    mvc.perform(get(url)).andExpect(status().isNotFound()).andReturn();
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -7,13 +7,22 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nih.nci.evs.api.model.Association;
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.ConceptResultList;
+import gov.nih.nci.evs.api.model.Definition;
+import gov.nih.nci.evs.api.model.MapResultList;
+import gov.nih.nci.evs.api.model.Property;
+import gov.nih.nci.evs.api.model.Synonym;
+import gov.nih.nci.evs.api.properties.ApplicationProperties;
+import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,18 +37,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.nih.nci.evs.api.model.Association;
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.ConceptResultList;
-import gov.nih.nci.evs.api.model.Definition;
-import gov.nih.nci.evs.api.model.MapResultList;
-import gov.nih.nci.evs.api.model.Property;
-import gov.nih.nci.evs.api.model.Synonym;
-import gov.nih.nci.evs.api.properties.ApplicationProperties;
-import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** Integration tests for SearchController. */
 @ExtendWith(SpringExtension.class)
@@ -81,10 +78,11 @@ public class SearchControllerTests {
     baseUrl = "/api/v1/concept/search";
     baseUrlNoTerm = "/api/v1/concept";
   }
-  
+
   @Test
   /**
    * test get trailing slash 404
+   *
    * @throws Exception
    */
   public void testGetTrailingSlashSearch() throws Exception {

--- a/src/test/java/gov/nih/nci/evs/api/controller/SubsetControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SubsetControllerTests.java
@@ -4,8 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.Property;
+import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,13 +23,6 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.Property;
-import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** subset tests. */
 @ExtendWith(SpringExtension.class)
@@ -57,10 +54,11 @@ public class SubsetControllerTests {
 
     baseUrl = "/api/v1/";
   }
-  
+
   @Test
   /**
    * test get trailing slash 404
+   *
    * @throws Exception
    */
   public void testGetTrailingSlashSubset() throws Exception {

--- a/src/test/java/gov/nih/nci/evs/api/controller/SubsetControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SubsetControllerTests.java
@@ -4,12 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nih.nci.evs.api.model.Concept;
-import gov.nih.nci.evs.api.model.Property;
-import gov.nih.nci.evs.api.properties.TestProperties;
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +19,13 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.nci.evs.api.model.Concept;
+import gov.nih.nci.evs.api.model.Property;
+import gov.nih.nci.evs.api.properties.TestProperties;
 
 /** subset tests. */
 @ExtendWith(SpringExtension.class)
@@ -53,6 +56,17 @@ public class SubsetControllerTests {
     JacksonTester.initFields(this, objectMapper);
 
     baseUrl = "/api/v1/";
+  }
+  
+  @Test
+  /**
+   * test get trailing slash 404
+   * @throws Exception
+   */
+  public void testGetTrailingSlashSubset() throws Exception {
+    String url = baseUrl + "/subset/ncit/C116978/?include=minimal";
+    log.info("Testing url - " + url);
+    mvc.perform(get(url)).andExpect(status().isNotFound()).andReturn();
   }
 
   /**

--- a/src/test/java/gov/nih/nci/evs/api/controller/VersionControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/VersionControllerTests.java
@@ -5,6 +5,10 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.nih.nci.evs.api.properties.TestProperties;
+import gov.nih.nci.evs.api.support.ApplicationVersion;
+import gov.nih.nci.evs.api.util.ConceptUtils;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -13,7 +17,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,12 +32,6 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import gov.nih.nci.evs.api.properties.TestProperties;
-import gov.nih.nci.evs.api.support.ApplicationVersion;
-import gov.nih.nci.evs.api.util.ConceptUtils;
 
 /** Integration tests for VersionController. */
 @ExtendWith(SpringExtension.class)
@@ -66,10 +63,11 @@ public class VersionControllerTests {
     this.objectMapper = new ObjectMapper();
     JacksonTester.initFields(this, objectMapper);
   }
-  
+
   @Test
   /**
    * test get trailing slash 404
+   *
    * @throws Exception
    */
   public void testGetTrailingSlashVersion() throws Exception {

--- a/src/test/java/gov/nih/nci/evs/api/controller/VersionControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/VersionControllerTests.java
@@ -5,10 +5,6 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nih.nci.evs.api.properties.TestProperties;
-import gov.nih.nci.evs.api.support.ApplicationVersion;
-import gov.nih.nci.evs.api.util.ConceptUtils;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -17,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +29,12 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.nci.evs.api.properties.TestProperties;
+import gov.nih.nci.evs.api.support.ApplicationVersion;
+import gov.nih.nci.evs.api.util.ConceptUtils;
 
 /** Integration tests for VersionController. */
 @ExtendWith(SpringExtension.class)
@@ -62,6 +65,17 @@ public class VersionControllerTests {
      */
     this.objectMapper = new ObjectMapper();
     JacksonTester.initFields(this, objectMapper);
+  }
+  
+  @Test
+  /**
+   * test get trailing slash 404
+   * @throws Exception
+   */
+  public void testGetTrailingSlashVersion() throws Exception {
+    String url = baseUrl + "/version/";
+    log.info("Testing url - " + url);
+    mvc.perform(get(url)).andExpect(status().isNotFound()).andReturn();
   }
 
   /**


### PR DESCRIPTION
https://tracker.nci.nih.gov/browse/EVSRESTAPI-561

we decided against supporting trailing slashes, so I've added a test into every controller that checks that trailing slashes cause a 404 API response.