### PR TITLE
shouldn't end devreset if we dont find a collection

### DIFF
--- a/src/main/bin/postman.sh
+++ b/src/main/bin/postman.sh
@@ -28,7 +28,7 @@ COLLECTION_FILE="EVSRESTAPI_Postman_${COLLECTION_NAME}_Demo.postman_collection.j
 # Check if the collection file exists
 if [ ! -f "$COLLECTION_FILE" ]; then
   echo "Warning: Collection file '$COLLECTION_FILE' for terminology '$COLLECTION_NAME' does not exist."
-  exit 1
+  exit 0
 fi
 
 # Verify if newman is installed


### PR DESCRIPTION
we don't want indexing to stop if it can't find a content qa for the current terminology

devreset and the like will not work until this is merged