### PR TITLE
add new endpoint for overview in evs-explore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ ext {
 
 /* Version info */
 group = "gov.nih.nci.evs.api"
-version = "2.1.0.RELEASE"
+version = "2.2.0.RELEASE"
 
 sourceCompatibility = 17
 targetCompatibility = 17

--- a/src/main/java/gov/nih/nci/evs/api/controller/MetadataController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/MetadataController.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -180,6 +181,91 @@ public class MetadataController extends BaseController {
       return terms;
     } catch (Exception e) {
       handleException(e, null);
+      return null;
+    }
+  }
+
+  /**
+   * Returns the metadata.
+   *
+   * @param terminology the terminology
+   * @return the metadata
+   * @throws Exception the exception
+   */
+  @Operation(
+      summary =
+          "Get some metadata (associations, properties, qualifiers, roles, term types, sources,"
+              + " definition types, synonym types) for the terminology overview tab in EVS-Explore")
+  @ApiResponses({
+    @ApiResponse(
+        responseCode = "200",
+        description = "Successfully retrieved the requested information"),
+    @ApiResponse(
+        responseCode = "404",
+        description = "Resource not found",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RestException.class))),
+    @ApiResponse(
+        responseCode = "417",
+        description = "Expectation failed",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = RestException.class)))
+  })
+  @Parameters({
+    @Parameter(
+        name = "terminology",
+        description =
+            "Terminology, e.g. 'ncit' or 'ncim' (<a"
+                + " href=\"https://github.com/NCIEVS/evsrestapi-client-SDK/blob/main/doc/TERMINOLOGIES.md\">See"
+                + " here for complete list</a>)",
+        required = true,
+        schema = @Schema(implementation = String.class))
+  })
+  @RecordMetric
+  @RequestMapping(
+      method = RequestMethod.GET,
+      value = "/metadata/{terminology}",
+      produces = "application/json")
+  public @ResponseBody Map<String, List<Concept>> getOverviewMetadata(
+      @PathVariable(value = "terminology") final String terminology) throws Exception {
+    Map<String, List<Concept>> metadata = new HashMap<>();
+    try {
+      metadata.put(
+          "associations",
+          metadataService.getAssociations(terminology, Optional.empty(), Optional.empty()));
+      metadata.put(
+          "properties",
+          metadataService.getProperties(terminology, Optional.empty(), Optional.empty()));
+      metadata.put(
+          "qualifiers",
+          metadataService.getQualifiers(terminology, Optional.empty(), Optional.empty()));
+      metadata.put(
+          "roles", metadataService.getRoles(terminology, Optional.empty(), Optional.empty()));
+      metadata.put(
+          "termTypes",
+          metadataService.getTermTypes(terminology).stream()
+              .map(Concept::new)
+              .collect(Collectors.toList()));
+      metadata.put(
+          "sources",
+          metadataService.getSynonymSources(terminology).stream()
+              .map(Concept::new)
+              .collect(Collectors.toList()));
+      metadata.put(
+          "definitionTypes",
+          metadataService.getDefinitionSources(terminology).stream()
+              .map(Concept::new)
+              .collect(Collectors.toList()));
+      metadata.put(
+          "synonymTypes",
+          metadataService.getSynonymTypes(terminology, Optional.empty(), Optional.empty()));
+      return metadata;
+    } catch (Exception e) {
+      handleException(e, terminology);
       return null;
     }
   }

--- a/src/test/java/gov/nih/nci/evs/api/controller/MetadataControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/MetadataControllerTests.java
@@ -177,6 +177,40 @@ public class MetadataControllerTests {
   }
 
   /**
+   * Test get metadata overview.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testGetOverviewMetadata() throws Exception {
+
+    String url = baseUrl + "/ncit";
+    log.info("Testing url - " + url);
+
+    MvcResult result = mvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+    String content = result.getResponse().getContentAsString();
+    log.info("  content = " + content);
+    Map<String, List<Concept>> metadata =
+        new ObjectMapper()
+            .readValue(
+                content,
+                new TypeReference<Map<String, List<Concept>>>() {
+                  // n/a
+                });
+    assertThat(metadata).isNotEmpty();
+
+    // check that all metadata groups are present for NCIt
+    assertThat(metadata.get("associations")).isNotEmpty();
+    assertThat(metadata.get("properties")).isNotEmpty();
+    assertThat(metadata.get("qualifiers")).isNotEmpty();
+    assertThat(metadata.get("roles")).isNotEmpty();
+    assertThat(metadata.get("termTypes")).isNotEmpty();
+    assertThat(metadata.get("sources")).isNotEmpty();
+    assertThat(metadata.get("definitionTypes")).isNotEmpty();
+    assertThat(metadata.get("synonymTypes")).isNotEmpty();
+  }
+
+  /**
    * Test get terminology metadata.
    *
    * @throws Exception the exception


### PR DESCRIPTION
added new endpoint to get all the metadata shown in the EVS-Explore overview tab. Makes for fewer calls to the backend in deciding which in the list should be greyed out.