### PR TITLE
add index runtime to terminology metadata

### DIFF
--- a/src/main/java/gov/nih/nci/evs/api/model/TerminologyMetadata.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/TerminologyMetadata.java
@@ -170,6 +170,9 @@ public class TerminologyMetadata extends BaseModel {
   /** The fhir publisher. */
   private String fhirPublisher;
 
+  /** The index runtime. */
+  private Long indexRuntime;
+
   /** Instantiates an empty {@link TerminologyMetadata}. */
   public TerminologyMetadata() {
     // n/a
@@ -240,6 +243,7 @@ public class TerminologyMetadata extends BaseModel {
     welcomeText = other.getWelcomeText();
     fhirUri = other.getFhirUri();
     fhirPublisher = other.getFhirPublisher();
+    indexRuntime = other.getIndexRuntime();
     extraSubsets = new HashMap<>(other.getExtraSubsets());
   }
 
@@ -1311,6 +1315,24 @@ public class TerminologyMetadata extends BaseModel {
    */
   public void setFhirPublisher(String fhirPublisher) {
     this.fhirPublisher = fhirPublisher;
+  }
+
+  /**
+   * Gets the index runtime in milliseconds.
+   *
+   * @return the index runtime
+   */
+  public Long getIndexRuntime() {
+    return indexRuntime;
+  }
+
+  /**
+   * Sets the index runtime.
+   *
+   * @param indexRuntime the new index runtime
+   */
+  public void setIndexRuntime(Long indexRuntime) {
+    this.indexRuntime = indexRuntime;
   }
 
   /**

--- a/src/main/java/gov/nih/nci/evs/api/service/LoaderServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/LoaderServiceImpl.java
@@ -215,7 +215,7 @@ public class LoaderServiceImpl {
       termAudit.setLogLevel("INFO");
       logger.info("Audit: {}", termAudit.toString());
       // only add new audit if something major has actually happened
-      if (termAudit.getElapsedTime() > 10000) {
+      if (termAudit.getElapsedTime() > 10000 && totalConcepts > 0) {
         addAudit(termAudit);
         // update the metadata with the elapsed time
         term.getMetadata().setIndexRuntime(termAudit.getElapsedTime());

--- a/src/main/java/gov/nih/nci/evs/api/service/LoaderServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/LoaderServiceImpl.java
@@ -217,6 +217,12 @@ public class LoaderServiceImpl {
       // only add new audit if something major has actually happened
       if (termAudit.getElapsedTime() > 10000) {
         addAudit(termAudit);
+        // update the metadata with the elapsed time
+        term.getMetadata().setIndexRuntime(termAudit.getElapsedTime());
+        logger.warn(
+            "index runtime of {} ms for terminology {}",
+            term.getMetadata().getIndexRuntime(),
+            term.getTerminology());
       }
 
     } catch (Exception e) {


### PR DESCRIPTION
EVSRESTAPI-502: add index runtime to metadata of terminology (in milliseconds)