### PR TITLE
Pva/evsrestapi 643 review writeonlyproperty

### DIFF
--- a/src/main/bin/load.sh
+++ b/src/main/bin/load.sh
@@ -23,7 +23,7 @@ fi
 dir=${arr[0]}
 
 # Hardcode the history file
-historyFile=$dir/cumulative_history_25.06e.txt
+historyFile=$dir/NCIT/cumulative_history_25.06e.txt
 
 
 databases=("NCIT2" "CTRP")

--- a/src/main/bin/reindex.sh
+++ b/src/main/bin/reindex.sh
@@ -20,7 +20,7 @@ if [ ${#arr[@]} -ne 0 ]; then
   echo "  e.g. $0"
   echo "  e.g. $0 --noconfig"
   echo "  e.g. $0 --force"
-  echo "  e.g. $0 --noconfig --history ../data/UnitTestData/cumulative_history_25.06e.txt"
+  echo "  e.g. $0 --noconfig --history ../data/UnitTestData/NCIT/cumulative_history_25.06e.txt"
   exit 1
 fi
 

--- a/src/main/bin/reindex.sh
+++ b/src/main/bin/reindex.sh
@@ -450,7 +450,7 @@ for x in `cat /tmp/y.$$.txt`; do
     # Otherwise, download if ncit
     elif [[ "$term" == "ncit" ]]; then
         download_ncit_history
-	fi
+	  fi
 	
     for y in `echo "evs_metadata concept_${term}_$cv evs_object_${term}_$cv"`; do
 

--- a/src/main/java/gov/nih/nci/evs/api/model/Definition.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Definition.java
@@ -11,7 +11,6 @@ import org.springframework.data.annotation.Transient;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Mapping;
-import org.springframework.data.elasticsearch.annotations.WriteOnlyProperty;
 
 /** Represents a synonym of a concept. */
 @Schema(description = "Represents a text definition for a concept")
@@ -28,7 +27,6 @@ public class Definition extends BaseModel implements Comparable<Definition> {
   /** The "code" of the definition type. */
   // In the future we can use @WriteOnlyProperty
   // this does not work: @JsonProperty(access = Access.READ_ONLY)
-  @WriteOnlyProperty
   @Field(type = FieldType.Keyword)
   private String code;
 
@@ -119,7 +117,6 @@ public class Definition extends BaseModel implements Comparable<Definition> {
    *
    * @return the code
    */
-  @Schema(hidden = true)
   public String getCode() {
     return code;
   }

--- a/src/main/java/gov/nih/nci/evs/api/model/Definition.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Definition.java
@@ -117,6 +117,7 @@ public class Definition extends BaseModel implements Comparable<Definition> {
    *
    * @return the code
    */
+  @Schema(description = "Definition code")
   public String getCode() {
     return code;
   }

--- a/src/main/java/gov/nih/nci/evs/api/model/Property.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Property.java
@@ -21,9 +21,6 @@ import org.springframework.data.elasticsearch.annotations.Mapping;
 public class Property extends BaseModel implements Comparable<Property> {
 
   /** The code. */
-  // In the future we can use @WriteOnlyProperty
-  // this does not work: @JsonProperty(access = Access.READ_ONLY)
-  // @WriteOnlyProperty
   @Field(type = FieldType.Keyword)
   private String code;
 

--- a/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
-import org.springframework.data.elasticsearch.annotations.WriteOnlyProperty;
 
 /**
  * Represents a qualifier on a synonym, definition, property, or role that isn't explicitly modeled
@@ -18,9 +17,6 @@ import org.springframework.data.elasticsearch.annotations.WriteOnlyProperty;
 public class Qualifier extends BaseModel implements Comparable<Qualifier> {
 
   /** The code. */
-  // In the future we can use @WriteOnlyProperty
-  // this does not work: @JsonProperty(access = Access.READ_ONLY)
-  @WriteOnlyProperty
   @Field(type = FieldType.Object, enabled = false)
   private String code;
 
@@ -74,7 +70,6 @@ public class Qualifier extends BaseModel implements Comparable<Qualifier> {
    *
    * @return the code
    */
-  @Schema(hidden = true)
   public String getCode() {
     return code;
   }

--- a/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
@@ -79,6 +79,7 @@ public class Qualifier extends BaseModel implements Comparable<Qualifier> {
    *
    * @param code the code
    */
+  @Schema(description = "Qualifier code")
   public void setCode(String code) {
     this.code = code;
   }

--- a/src/main/java/gov/nih/nci/evs/api/model/Relationship.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Relationship.java
@@ -80,6 +80,7 @@ public class Relationship extends BaseModel implements Comparable<Relationship> 
    *
    * @return the code
    */
+  @Schema(description = "Relationship code")
   public String getCode() {
     return code;
   }

--- a/src/main/java/gov/nih/nci/evs/api/model/Relationship.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Relationship.java
@@ -11,7 +11,6 @@ import org.springframework.data.annotation.Transient;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Mapping;
-import org.springframework.data.elasticsearch.annotations.WriteOnlyProperty;
 
 /** Represents a connection between two concepts. */
 @Schema(description = "Represents a connection between two concepts")
@@ -19,9 +18,6 @@ import org.springframework.data.elasticsearch.annotations.WriteOnlyProperty;
 public class Relationship extends BaseModel implements Comparable<Relationship> {
 
   /** The code. */
-  // In the future we can use @WriteOnlyProperty
-  // this does not work: @JsonProperty(access = Access.READ_ONLY)
-  @WriteOnlyProperty
   @Field(type = FieldType.Keyword)
   private String code;
 
@@ -84,7 +80,6 @@ public class Relationship extends BaseModel implements Comparable<Relationship> 
    *
    * @return the code
    */
-  @Schema(hidden = true)
   public String getCode() {
     return code;
   }

--- a/src/main/java/gov/nih/nci/evs/api/model/Synonym.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Synonym.java
@@ -48,10 +48,6 @@ public class Synonym extends BaseModel implements Comparable<Synonym> {
   private String type;
 
   /** The "code" of the synonym type, so it can be searched by. */
-  // In the future we can use @WriteOnlyProperty
-  // this does not work: @JsonProperty(access = Access.READ_ONLY)
-  @WriteOnlyProperty
-  @Field(type = FieldType.Keyword)
   private String typeCode;
 
   /** The source. */
@@ -232,7 +228,6 @@ public class Synonym extends BaseModel implements Comparable<Synonym> {
    *
    * @return the type code
    */
-  @Schema(hidden = true)
   public String getTypeCode() {
     return typeCode;
   }

--- a/src/main/java/gov/nih/nci/evs/api/model/Synonym.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Synonym.java
@@ -48,6 +48,7 @@ public class Synonym extends BaseModel implements Comparable<Synonym> {
   private String type;
 
   /** The "code" of the synonym type, so it can be searched by. */
+  @Field(type = FieldType.Keyword)
   private String typeCode;
 
   /** The source. */
@@ -228,6 +229,7 @@ public class Synonym extends BaseModel implements Comparable<Synonym> {
    *
    * @return the type code
    */
+  @Schema(description = "Synonym Type code")
   public String getTypeCode() {
     return typeCode;
   }


### PR DESCRIPTION
https://tracker.nci.nih.gov/browse/EVSRESTAPI-643: Removes @WriteOnlyProperty from code fields in Qualifer, Relationship, Definition, Synonym. Edits tests checking that codes from these models were hidden.