### PR TITLE
Pva/evsrestapi 548 source terminology version

### DIFF
--- a/src/main/java/gov/nih/nci/evs/api/controller/ConceptController.java
+++ b/src/main/java/gov/nih/nci/evs/api/controller/ConceptController.java
@@ -341,33 +341,32 @@ public class ConceptController extends BaseController {
         throw new ResponseStatusException(HttpStatus.NOT_FOUND, code + " not found");
       }
 
-      // Comment this out for 2.0 because it allows "old" NCIt mappings to show up.
-      //      if (ip.isMaps()) {
-      //        List<Mapping> firstList = concept.get().getMaps();
-      //        List<Mapping> secondList =
-      //            openSearchService.getConceptMappings(Arrays.asList(code), terminology);
-      //
-      //        // Create a set of existing keys in firstList to check for matches
-      //        Set<String> existingKeys =
-      //            firstList.stream()
-      //                .map(map -> map.getTargetTerminology() + "_" + map.getTargetCode())
-      //                .collect(Collectors.toSet());
-      //
-      //        // Filter and add only those ConceptMap objects that don't have a match in firstList
-      //        List<Mapping> mapsToAdd =
-      //            secondList.stream()
-      //                .filter(
-      //                    cm ->
-      //                        !existingKeys.contains(
-      //                            cm.getTargetTerminology() + "_" + cm.getTargetCode()))
-      //                .collect(Collectors.toList());
-      //
-      //        // Add the filtered list to firstList
-      //        firstList.addAll(mapsToAdd);
-      //
-      //        // Set the updated list back to the concept
-      //        concept.get().setMaps(firstList);
-      //      }
+      if (ip.isMaps()) {
+        List<Mapping> firstList = concept.get().getMaps();
+        List<Mapping> secondList =
+            openSearchService.getConceptMappings(Arrays.asList(code), terminology);
+
+        // Create a set of existing keys in firstList to check for matches
+        Set<String> existingKeys =
+            firstList.stream()
+                .map(map -> map.getTargetTerminology() + "_" + map.getTargetCode())
+                .collect(Collectors.toSet());
+
+        // Filter and add only those ConceptMap objects that don't have a match in firstList
+        List<Mapping> mapsToAdd =
+            secondList.stream()
+                .filter(
+                    cm ->
+                        !existingKeys.contains(
+                            cm.getTargetTerminology() + "_" + cm.getTargetCode()))
+                .collect(Collectors.toList());
+
+        // Add the filtered list to firstList
+        firstList.addAll(mapsToAdd);
+
+        // Set the updated list back to the concept
+        concept.get().setMaps(firstList);
+      }
 
       if (limit.isPresent()) {
         if (limit.get().intValue() < 1 || limit.get().intValue() > 100) {

--- a/src/main/java/gov/nih/nci/evs/api/service/AbstractGraphLoadServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/AbstractGraphLoadServiceImpl.java
@@ -959,8 +959,8 @@ public abstract class AbstractGraphLoadServiceImpl extends BaseLoaderService {
     map.getProperties()
         .add(new Property("date", FhirUtility.convertToYYYYMMDD(sourceTerminology.getDate())));
     map.getProperties().add(new Property("downloadOnly", "false"));
-    // map.getProperties().add(new Property("welcomeText", "NCIt_maps_to_" + targetTermName +
-    // ".html"));
+    map.getProperties()
+        .add(new Property("welcomeText", "mapping_nci_" + targetTermName.toLowerCase() + ".html"));
     map.getProperties().add(new Property("sourceTerminology", "NCIt"));
     map.getProperties()
         .add(new Property("sourceTerminologyVersion", sourceTerminology.getVersion()));

--- a/src/main/java/gov/nih/nci/evs/api/service/AbstractGraphLoadServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/AbstractGraphLoadServiceImpl.java
@@ -976,14 +976,16 @@ The browser links each mapped concept to that concept's page in the current prod
     map.getProperties()
         .add(new Property("sourceTerminologyVersion", sourceTerminology.getVersion()));
     map.getProperties().add(new Property("targetTerminology", targetTermName));
-    map.getProperties()
-        .add(
-            new Property(
-                "targetTerminologyVersion",
-                targetTerminology != null ? targetTerminology.getVersion() : null));
+    if (targetTerminology != null
+        && targetTerminology.getVersion() != null
+        && !targetTerminology.getVersion().isEmpty()) {
+      map.getProperties()
+          .add(new Property("targetTerminologyVersion", targetTerminology.getVersion()));
+      map.getProperties().add(new Property("targetLoaded", "true"));
+    } else {
+      map.getProperties().add(new Property("targetLoaded", "false"));
+    }
     map.getProperties().add(new Property("sourceLoaded", "true"));
-    map.getProperties()
-        .add(new Property("targetLoaded", targetTerminology != null ? "true" : "false"));
     map.getProperties().add(new Property("mapsetLink", null));
     map.getProperties().add(new Property("loader", "AbstractGraphLoadServiceImpl"));
     return map;

--- a/src/main/java/gov/nih/nci/evs/api/service/AbstractGraphLoadServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/AbstractGraphLoadServiceImpl.java
@@ -967,7 +967,7 @@ This is a manual EVS mapping of concepts with equivalent meaning in the source a
 <br>
 &nbsp;&nbsp;&nbsp;Target: %s %s
 <br><br>
-The browser links each mapped concept to that concept's page in the current production version of its terminology. There are currently no links for GDC, as it is not indexed in this tool.
+The browser links each mapped concept to that concept's page in the current production version of its terminology.
 <br><br>
 """
             .formatted(sourceTerminology.getVersion(), targetTermName, termFullNameAndVersion);

--- a/src/main/java/gov/nih/nci/evs/api/service/BaseLoaderService.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/BaseLoaderService.java
@@ -69,6 +69,10 @@ public abstract class BaseLoaderService implements OpensearchLoadService {
   @Value("${nci.evs.bulkload.graphDbs}")
   private String dbs;
 
+  public TerminologyUtils getTerminologyUtils() {
+    return termUtils;
+  }
+
   /**
    * build config object from command line options.
    *

--- a/src/main/java/gov/nih/nci/evs/api/service/MappingLoaderServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/MappingLoaderServiceImpl.java
@@ -141,6 +141,7 @@ public class MappingLoaderServiceImpl extends BaseLoaderService {
           conceptToAdd.setSource(metadata[5]);
           conceptToAdd.setSourceTerminology(
               sourceTerminology.getMetadata().getUiLabel().replaceAll(" ", "_"));
+          conceptToAdd.setSourceTerminologyVersion(sourceTerminology.getVersion());
           conceptToAdd.setType("mapsTo");
           conceptToAdd.setRank("1");
           conceptToAdd.setTargetCode(conceptSplit[1].strip());

--- a/src/test/java/gov/nih/nci/evs/api/controller/MapsetControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/MapsetControllerTests.java
@@ -662,6 +662,91 @@ public class MapsetControllerTests {
     assertEquals(10, mapList.getMaps().size());
   }
 
+  @Test
+  public void testNciMapsToViewable() throws Exception {
+    String path = "NCIt_Maps_To_ICD9CM";
+    String params = "?include=properties";
+    MvcResult result =
+        mvc.perform(get(baseUrl + "/" + path + params)).andExpect(status().isOk()).andReturn();
+    String content = result.getResponse().getContentAsString();
+    assertNotNull(content);
+    Concept singleMetadataMap = new ObjectMapper().readValue(content, Concept.class);
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("downloadOnly")
+                        && property.getValue().equals("false")));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("welcomeText") && property.getValue() != null));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("sourceTerminologyVersion")
+                        && property.getValue() != null));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("targetTerminologyVersion")
+                        && property.getValue() != null));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("sourceLoaded")
+                        && property.getValue().equals("true")));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("targetLoaded")
+                        && property.getValue().equals("true")));
+
+    // GDC is not loaded so it has slightly different properties
+    path = "NCIt_Maps_To_GDC";
+    result = mvc.perform(get(baseUrl + "/" + path + params)).andExpect(status().isOk()).andReturn();
+    content = result.getResponse().getContentAsString();
+    assertNotNull(content);
+    singleMetadataMap = new ObjectMapper().readValue(content, Concept.class);
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("downloadOnly")
+                        && property.getValue().equals("false")));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("welcomeText") && property.getValue() != null));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("sourceTerminologyVersion")
+                        && property.getValue() != null));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .noneMatch(property -> property.getType().equals("targetTerminologyVersion")));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("sourceLoaded")
+                        && property.getValue().equals("true")));
+    assertTrue(
+        singleMetadataMap.getProperties().stream()
+            .anyMatch(
+                property ->
+                    property.getType().equals("targetLoaded")
+                        && property.getValue().equals("false")));
+  }
+
   /**
    * Test mapsets with retired concepts.
    *


### PR DESCRIPTION
Updates mappings to support sourceTerminologyVersion and adds more metadata information to NCIt_maps_to mappings to facilitate moving them to viewable maps.