### PR TITLE
Pva/evsrestapi 641 update for new chebi

### DIFF
--- a/src/main/java/gov/nih/nci/evs/api/model/Concept.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Concept.java
@@ -1011,7 +1011,6 @@ public class Concept extends ConceptMinimal {
     normName = null;
     stemName = null;
     getSynonyms().forEach(s -> s.clearHidden());
-    getQualifiers().forEach(q -> q.clearHidden());
     getProperties().forEach(p -> p.clearHidden());
     getDefinitions().forEach(d -> d.clearHidden());
     getAssociations().forEach(r -> r.clearHidden());

--- a/src/main/java/gov/nih/nci/evs/api/model/Concept.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Concept.java
@@ -1011,11 +1011,5 @@ public class Concept extends ConceptMinimal {
     normName = null;
     stemName = null;
     getSynonyms().forEach(s -> s.clearHidden());
-    getProperties().forEach(p -> p.clearHidden());
-    getDefinitions().forEach(d -> d.clearHidden());
-    getAssociations().forEach(r -> r.clearHidden());
-    getInverseAssociations().forEach(r -> r.clearHidden());
-    getRoles().forEach(r -> r.clearHidden());
-    getInverseRoles().forEach(r -> r.clearHidden());
   }
 }

--- a/src/main/java/gov/nih/nci/evs/api/model/Definition.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Definition.java
@@ -244,7 +244,4 @@ public class Definition extends BaseModel implements Comparable<Definition> {
   public int compareTo(Definition o) {
     return (definition + "").compareTo(o.getDefinition() + "");
   }
-
-  /** Clear hidden. */
-  public void clearHidden() {}
 }

--- a/src/main/java/gov/nih/nci/evs/api/model/Definition.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Definition.java
@@ -246,8 +246,5 @@ public class Definition extends BaseModel implements Comparable<Definition> {
   }
 
   /** Clear hidden. */
-  public void clearHidden() {
-    code = null;
-    getQualifiers().forEach(q -> q.clearHidden());
-  }
+  public void clearHidden() {}
 }

--- a/src/main/java/gov/nih/nci/evs/api/model/Property.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Property.java
@@ -262,10 +262,4 @@ public class Property extends BaseModel implements Comparable<Property> {
   public int compareTo(Property o) {
     return (type + value).compareToIgnoreCase(o.getType() + o.getValue());
   }
-
-  /** Clear hidden. */
-  public void clearHidden() {
-    code = null;
-    getQualifiers().forEach(q -> q.clearHidden());
-  }
 }

--- a/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
@@ -1,6 +1,5 @@
 package gov.nih.nci.evs.api.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
@@ -12,7 +12,6 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
  * as a first-class attribute.
  */
 @Schema(description = "Represents a type/value qualifier on a concept element")
-@JsonIgnoreProperties(value = {"code"})
 @JsonInclude(Include.NON_EMPTY)
 public class Qualifier extends BaseModel implements Comparable<Qualifier> {
 

--- a/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Qualifier.java
@@ -47,6 +47,19 @@ public class Qualifier extends BaseModel implements Comparable<Qualifier> {
   /**
    * Instantiates a {@link Qualifier} from the specified parameters.
    *
+   * @param type the type
+   * @param value the value
+   * @param code the code
+   */
+  public Qualifier(final String type, final String value, final String code) {
+    this.type = type;
+    this.value = value;
+    this.code = code;
+  }
+
+  /**
+   * Instantiates a {@link Qualifier} from the specified parameters.
+   *
    * @param other the other
    */
   public Qualifier(final Qualifier other) {
@@ -70,6 +83,7 @@ public class Qualifier extends BaseModel implements Comparable<Qualifier> {
    *
    * @return the code
    */
+  @Schema(description = "Qualifier code")
   public String getCode() {
     return code;
   }
@@ -79,7 +93,6 @@ public class Qualifier extends BaseModel implements Comparable<Qualifier> {
    *
    * @param code the code
    */
-  @Schema(description = "Qualifier code")
   public void setCode(String code) {
     this.code = code;
   }
@@ -169,7 +182,5 @@ public class Qualifier extends BaseModel implements Comparable<Qualifier> {
   }
 
   /** Clear hidden. */
-  public void clearHidden() {
-    code = null;
-  }
+  public void clearHidden() {}
 }

--- a/src/main/java/gov/nih/nci/evs/api/model/Relationship.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Relationship.java
@@ -275,7 +275,4 @@ public class Relationship extends BaseModel implements Comparable<Relationship> 
     return (relatedName + source + relatedCode + type)
         .compareToIgnoreCase(o.getRelatedName() + o.getSource() + o.getRelatedCode() + o.getType());
   }
-
-  /** Clear hidden. */
-  public void clearHidden() {}
 }

--- a/src/main/java/gov/nih/nci/evs/api/model/Relationship.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Relationship.java
@@ -277,8 +277,5 @@ public class Relationship extends BaseModel implements Comparable<Relationship> 
   }
 
   /** Clear hidden. */
-  public void clearHidden() {
-    code = null;
-    getQualifiers().forEach(q -> q.clearHidden());
-  }
+  public void clearHidden() {}
 }

--- a/src/main/java/gov/nih/nci/evs/api/model/Synonym.java
+++ b/src/main/java/gov/nih/nci/evs/api/model/Synonym.java
@@ -440,7 +440,5 @@ public class Synonym extends BaseModel implements Comparable<Synonym> {
   public void clearHidden() {
     normName = null;
     stemName = null;
-    typeCode = null;
-    getQualifiers().forEach(q -> q.clearHidden());
   }
 }

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -402,7 +402,7 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
           if (property.getCode().equals(terminology.getMetadata().getConceptStatus())) {
             // Set to retired if it matches config
             if (property.getValue().equals(terminology.getMetadata().getRetiredStatusValue())) {
-              concept.setConceptStatus(property.getValue());
+              concept.setConceptStatus("Retired_Concept");
               concept.setActive(false);
             } else {
               concept.setConceptStatus(property.getValue());
@@ -2157,11 +2157,20 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
       // Send URI or code
       final Concept concept =
           getRole(role.getUri() != null ? role.getUri() : role.getCode(), terminology, ip);
-      final gov.nih.nci.evs.api.model.sparql.Bindings matchConcept =
-          Stream.of(bindings)
-              .filter(binding -> binding.getProperty().getValue().equals(concept.getUri()))
-              .findFirst()
-              .orElse(null);
+      gov.nih.nci.evs.api.model.sparql.Bindings matchConcept = null;
+      if (role.getUri() != null) {
+        matchConcept =
+            Stream.of(bindings)
+                .filter(binding -> binding.getProperty().getValue().equals(concept.getUri()))
+                .findFirst()
+                .orElse(null);
+      } else {
+        matchConcept =
+            Stream.of(bindings)
+                .filter(binding -> binding.getPropertyCode().getValue().equals(concept.getCode()))
+                .findFirst()
+                .orElse(null);
+      }
       if (concept.getCode().equals(concept.getName())
           && bindings != null
           && matchConcept != null

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -1632,7 +1632,7 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
                   propertyCode,
                   propertyUri);
           if (name != null) {
-            axiomObject.getQualifiers().add(new Qualifier(name, labelValue));
+            axiomObject.getQualifiers().add(new Qualifier(name, labelValue, propertyCode));
           }
           // log.debug(" qualifier = " + name + ", " + labelValue + ", " +
           // propertyCode);

--- a/src/main/java/gov/nih/nci/evs/api/util/EVSUtils.java
+++ b/src/main/java/gov/nih/nci/evs/api/util/EVSUtils.java
@@ -9,6 +9,7 @@ import gov.nih.nci.evs.api.model.Qualifier;
 import gov.nih.nci.evs.api.model.Synonym;
 import gov.nih.nci.evs.api.model.Terminology;
 import gov.nih.nci.evs.api.model.sparql.Bindings;
+import gov.nih.nci.evs.api.service.MetadataService;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
@@ -24,6 +25,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /** Utilities for handling EVS stuff. */
 public class EVSUtils {
@@ -31,6 +33,9 @@ public class EVSUtils {
   /** The Constant log. */
   @SuppressWarnings("unused")
   private static final Logger log = LoggerFactory.getLogger(EVSUtils.class);
+
+  /** The metadata service. */
+  @Autowired private static MetadataService metadataService;
 
   /**
    * Returns the qualifier name.
@@ -238,6 +243,21 @@ public class EVSUtils {
         while (attrMatcher.find()) {
           final Qualifier qualifier = new Qualifier();
           qualifier.setType("attribution");
+          try { // Try to get the qualifier code from the metadata service
+            Concept attributeConcept =
+                metadataService
+                    .getQualifier(
+                        terminology.getTerminology(), qualifier.getType(), Optional.of("minimal"))
+                    .orElse(null);
+            if (attributeConcept != null && attributeConcept.getCode() != null) {
+              qualifier.setCode(attributeConcept.getCode());
+            } else {
+              log.warn("No qualifier code found for type: " + qualifier.getType());
+            }
+          } catch (Exception e) {
+            // If it fails, just use the type as is
+            log.warn("Unable to get qualifier code for: " + qualifier.getType(), e);
+          }
           qualifier.setValue(attrMatcher.group(1));
           def.getQualifiers().add(qualifier);
         }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -77,8 +77,8 @@ nci:
       metricsDir: ${METRICS_DIR:/tmp}
       configBaseUri: ${CONFIG_BASE_URI:https://raw.githubusercontent.com/NCIEVS/evsrestapi-operations/develop/config/metadata}
       uiLicense: ${UI_LICENSE:ui-license}
-      unitTestData: ${UNIT_TEST_DATA:../data/UnitTestData/}
-      childhoodNeoplasmSubsetsXls: ${CHILDHOOD_NEOPLASM_SUBSETS_XLS:NCIT/Childhood_Neoplasm_Subsets.xls}
+      unitTestData: ${UNIT_TEST_DATA:../data/UnitTestData/NCIT/}
+      childhoodNeoplasmSubsetsXls: ${CHILDHOOD_NEOPLASM_SUBSETS_XLS:Childhood_Neoplasm_Subsets.xls}
       ftpNeoplasmUrl: ${FTP_NEOPLASM_URL:https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/Neoplasm/}
     bulkload:
       historyDir: ${NCI_EVS_HISTORY_DIR:src/main/resources/cumulative_history_25.06e.txt}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,8 +82,8 @@ nci:
       metricsDir: ${METRICS_DIR}
       configBaseUri: ${CONFIG_BASE_URI:https://raw.githubusercontent.com/NCIEVS/evsrestapi-operations/main/config/metadata}
       uiLicense: ${UI_LICENSE:ui-license}
-      unitTestData: ${UNIT_TEST_DATA:../data/UnitTestData/}
-      childhoodNeoplasmSubsetsXls: ${CHILDHOOD_NEOPLASM_SUBSETS_XLS:NCIT/Childhood_Neoplasm_Subsets.xls}
+      unitTestData: ${UNIT_TEST_DATA:../data/UnitTestData/NCIT/}
+      childhoodNeoplasmSubsetsXls: ${CHILDHOOD_NEOPLASM_SUBSETS_XLS:Childhood_Neoplasm_Subsets.xls}
       ftpNeoplasmUrl: ${FTP_NEOPLASM_URL:https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/Neoplasm/}
     bulkload:
       historyDir: ${NCI_EVS_HISTORY_DIR:/tmp}

--- a/src/main/resources/metadata/ncit.txt
+++ b/src/main/resources/metadata/ncit.txt
@@ -1,3 +1,4 @@
 # Sample concepts to include in report
 C3224
 C100110
+C101669

--- a/src/main/resources/sparql-queries.properties
+++ b/src/main/resources/sparql-queries.properties
@@ -84,9 +84,15 @@ axiom.qualifier=SELECT DISTINCT ?propertyValue \
 } \
 ORDER BY ?propertyValue
 
-properties=SELECT ?property ?propertyCode ?propertyLabel ?propertyValue \
+properties=SELECT DISTINCT ?property ?propertyCode ?propertyLabel ?propertyValue \
 { GRAPH <#{namedGraph}> \
   { \
+    { \
+      ?x #{codeCode} "#{conceptCode}" . \
+      ?x owl:deprecated ?propertyValue . \
+      BIND(<http://www.w3.org/2002/07/owl#deprecated> AS ?property) \
+    } \
+    UNION \
     { \
       ?x #{codeCode} "#{conceptCode}" . \
       ?x ?property ?propertyValue . \
@@ -109,9 +115,16 @@ properties=SELECT ?property ?propertyCode ?propertyLabel ?propertyValue \
 } \
 ORDER BY ?propertyCode ?propertyLabel
 
-properties.batch=SELECT ?conceptCode ?property ?propertyCode ?propertyLabel ?propertyValue \
+properties.batch=SELECT DISTINCT ?conceptCode ?property ?propertyCode ?propertyLabel ?propertyValue \
 { GRAPH <#{namedGraph}> \
   { \
+    { \
+      ?x #{codeCode} ?conceptCode . \
+      FILTER (?conceptCode IN (#{inClause})) . \
+      ?x owl:deprecated ?propertyValue . \
+      BIND(<http://www.w3.org/2002/07/owl#deprecated> AS ?property) \
+    } \
+    UNION \
     { \
       ?x a owl:Class . \
       ?x #{codeCode} ?conceptCode . \
@@ -1005,6 +1018,8 @@ all.properties=SELECT DISTINCT ?property ?propertyCode ?propertyLabel \
       { ?property a owl:AnnotationProperty } \
       UNION \
       { ?property a owl:DatatypeProperty } \
+      UNION \
+      { FILTER(?property = owl:deprecated) } \
     } \
     OPTIONAL { ?property #{preferredNameCode} ?propertyLabel } . \
     OPTIONAL { ?property #{codeCode} ?propertyCode } . \

--- a/src/test/java/gov/nih/nci/evs/api/ConceptSampleTester.java
+++ b/src/test/java/gov/nih/nci/evs/api/ConceptSampleTester.java
@@ -992,16 +992,14 @@ public class ConceptSampleTester {
     return concept.getProperties().stream()
         .filter(
             o ->
-                o.getType().equals(otherProperty.getName())
-                    || o.getType().equals(otherProperty.getCode())
-                        && o.getQualifiers() != null
-                        && o.getQualifiers().stream()
-                            .filter(
-                                p ->
-                                    p.getType().equals(otherQualifier.getName())
-                                        && p.getValue().equals(propertyValue))
-                            .findAny()
-                            .isPresent())
+                (o.getCode().equals(otherProperty.getName())
+                        || o.getCode().equals(otherProperty.getCode()))
+                    && o.getQualifiers() != null
+                    && o.getQualifiers().stream()
+                        .anyMatch(
+                            p ->
+                                p.getType().equals(otherQualifier.getName())
+                                    && p.getValue().equals(propertyValue)))
         .findAny()
         .isPresent();
   }
@@ -1098,7 +1096,7 @@ public class ConceptSampleTester {
       return concept.getSynonyms().stream()
           .filter(
               o ->
-                  o.getType().equals(otherProperty.getName())
+                  o.getTypeCode().equals(otherProperty.getCode())
                       && o.getQualifiers() != null
                       && o.getQualifiers().stream()
                           .filter(

--- a/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/ConceptControllerTests.java
@@ -2100,7 +2100,7 @@ public class ConceptControllerTests {
     String content;
     Concept concept;
 
-    // C101669 has synonyms, definitions
+    // C101669 has synonyms, definitions, qualifier codes
     url = baseUrl + "/ncit/C101669?include=full";
     result = mvc.perform(get(url)).andExpect(status().isOk()).andReturn();
     content = result.getResponse().getContentAsString();
@@ -2110,6 +2110,14 @@ public class ConceptControllerTests {
     assertThat(concept.getDefinitions().get(0).getCode() != null).isTrue();
     assertThat(concept.getProperties().get(0).getCode() != null).isTrue();
     assertThat(concept.getAssociations().get(0).getCode() != null).isTrue();
+    // C101669 has a definition with a qualifier
+    assertThat(
+            concept.getDefinitions().stream()
+                .anyMatch(
+                    def ->
+                        !def.getQualifiers().isEmpty()
+                            && def.getQualifiers().get(0).getCode() != null))
+        .isTrue();
 
     // C3224 lacks qualifiers, but should have code for other types
     url = baseUrl + "/ncit/C3224?include=full";


### PR DESCRIPTION
EVSRESTAPI-641: support new chebi file formattings

- Edits sparql queries to support directly finding deprecated concepts (new chebi has removed owl:deprecated as annotation property)
- properly sets concept_status as retired_concept when it matches the config
- checks which role field was used to find a concept before trying to find it's matching role
- fix regressions in qualifier and synonym sample testing
- also fixes qualifier codes now showing in api calls