### PR TITLE
fix mged crash on reindex in roles

### DIFF
--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -2153,6 +2153,7 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
     }
 
     for (final Role role : roles) {
+      log.info("ROLE: {}", role.toString());
 
       // Send URI or code
       final Concept concept =
@@ -2161,15 +2162,22 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
       if (role.getUri() != null) {
         matchConcept =
             Stream.of(bindings)
-                .filter(binding -> binding.getProperty().getValue().equals(concept.getUri()))
+                .filter(
+                    binding ->
+                        binding.getPropertyCode() != null
+                            && binding.getProperty().getValue().equals(concept.getUri()))
                 .findFirst()
                 .orElse(null);
       } else {
         matchConcept =
             Stream.of(bindings)
-                .filter(binding -> binding.getPropertyCode().getValue().equals(concept.getCode()))
+                .filter(
+                    binding ->
+                        binding.getPropertyCode() != null
+                            && binding.getPropertyCode().getValue().equals(concept.getCode()))
                 .findFirst()
                 .orElse(null);
+        log.info("  MATCH: {}", matchConcept);
       }
       if (concept.getCode().equals(concept.getName())
           && bindings != null

--- a/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SparqlQueryManagerServiceImpl.java
@@ -2153,7 +2153,6 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
     }
 
     for (final Role role : roles) {
-      log.info("ROLE: {}", role.toString());
 
       // Send URI or code
       final Concept concept =
@@ -2177,7 +2176,6 @@ public class SparqlQueryManagerServiceImpl implements SparqlQueryManagerService 
                             && binding.getPropertyCode().getValue().equals(concept.getCode()))
                 .findFirst()
                 .orElse(null);
-        log.info("  MATCH: {}", matchConcept);
       }
       if (concept.getCode().equals(concept.getName())
           && bindings != null


### PR DESCRIPTION
https://tracker.nci.nih.gov/browse/EVSRESTAPI-665: crashing on reindex of mged terminology

fixed by accounting for bindings with null propertyCode