### PR TITLE
Pva/evsrestapi 407 replace old samples

### DIFF
--- a/src/test/java/gov/nih/nci/evs/api/controller/Icd10SampleTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/Icd10SampleTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import gov.nih.nci.evs.api.model.Concept;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +16,10 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nih.nci.evs.api.model.Concept;
 
 /** NCIt samples test. */
 @ExtendWith(SpringExtension.class)
@@ -55,14 +57,14 @@ public class Icd10SampleTest extends SampleTest {
     Concept concept = null;
 
     // Test active
-    url = "/api/v1/concept/icd10/A00-A09";
+    url = "/api/v1/concept/icd10/M14.6";
     log.info("Testing url - " + url);
     result = testMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
     content = result.getResponse().getContentAsString();
     log.info(" content = " + content);
     concept = new ObjectMapper().readValue(content, Concept.class);
     assertThat(concept).isNotNull();
-    assertThat(concept.getCode()).isEqualTo("A00-A09");
+    assertThat(concept.getCode()).isEqualTo("M14.6");
     assertThat(concept.getTerminology()).isEqualTo("icd10");
     assertThat(concept.getActive()).isTrue();
   }

--- a/src/test/resources/samples/icd10-samples.txt
+++ b/src/test/resources/samples/icd10-samples.txt
@@ -1,62 +1,24 @@
+# no version changes so we use the old sample file
 R10.0	R10.0	synonym	Acute abdomen
 R10.0	R10.0	term-type	PT
-A42	A42	term-type	HT
-D59	D59	term-type	MTH_HT
-D59.9	D59.9	term-type	MTH_PT
+K90.0	K90.0	term-type	MTH_PT
+D83	D83	term-type	HT
+K20-K31	K20-K31	term-type	MTH_HT
 R10.0	R10.0	INCLUSION_TERM	Severe abdominal pain (generalized)(localized)(with abdominal rigidity)
 M14.6	M14.6	IAN	aster
 R10.0	R10.0	Semantic_Type	Sign or Symptom
 Q89.9	Q89.9	Semantic_Type	Congenital Abnormality
-D68.4	D68.4	Semantic_Type	Disease or Syndrome
-M24.6	M24.6	Semantic_Type	Acquired Abnormality
-F99	F99	Semantic_Type	Mental or Behavioral Dysfunction
-O82.9	O82.9	Semantic_Type	Therapeutic or Preventive Procedure
-K63.5	K63.5	Semantic_Type	Anatomical Abnormality
-T36-T50	T36-T50	Semantic_Type	Injury or Poisoning
-R60.9	R60.9	Semantic_Type	Pathologic Function
-O88.1	O88.1	Semantic_Type	Finding
-C96.6	C96.6	Semantic_Type	Neoplastic Process
-T66	T66	Semantic_Type	Biologic Function
-U00-U49	U00-U49	Semantic_Type	Intellectual Product
-M24.6	M24.6	root
-I70	I70	root
-F99-F99	F99-F99	root
-I63	I63	root
+A42.1	A42.1	Semantic_Type	Disease or Syndrome
+K40-K46	K40-K46	Semantic_Type	Anatomical Abnormality
+R19.2	R19.2	Semantic_Type	Finding
+S36	S36	Semantic_Type	Injury or Poisoning
+E14.8	E14.8	Semantic_Type	Pathologic Function
+K09	K09	Semantic_Type	Acquired Abnormality
+XXII	XXII	Semantic_Type	Intellectual Product
+N30	N30	root
 XI	XI	root
-B02	B02	root
-C81	C81	root
-C95	C95	root
-VI	VI	root
-F45	F45	root
-Q96	Q96	root
-B34	B34	root
-XIV	XIV	root
-I21	I21	root
-Q24	Q24	root
-XII	XII	root
-XVI	XVI	root
-XXI	XXI	root
+M25.9	M25.9	root
 XIII	XIII	root
-T01	T01	root
-C15-C26	C15-C26	root
-II	II	root
-P35	P35	root
-F80-F89	F80-F89	root
-I	I	root
+S36	S36	root
 III	III	root
-XVII	XVII	root
-XVIII	XVIII	root
-XIX	XIX	root
-IX	IX	root
-N92	N92	root
-VII	VII	root
-I60	I60	root
-Q05	Q05	root
-IV	IV	root
-XV	XV	root
-C46	C46	root
-I42	I42	root
-I50	I50	root
-XXII	XXII	root
-I22	I22	root
-R10.0	R10.0	parent-count1
+M14.6	M14.6	parent-count1

--- a/src/test/resources/samples/icd9cm-samples.txt
+++ b/src/test/resources/samples/icd9cm-samples.txt
@@ -2,63 +2,34 @@
 740-759.99	740-759.99	term-type	HT
 759.9	759.9	term-type	AB
 759.9	759.9	term-type	PT
-286.7	286.7	qualifier-synonym~ICE	Acquired coagulation factor deficiency~Deficiency of coagulation factor due to: {liver disease; vitamin K deficiency}; Hypoprothrombinemia, acquired
-286.7	286.7	qualifier-synonym~SOS	Acquired coagulation factor deficiency~Excludes: vitamin K deficiency of newborn (776.0); Use additional E-code to identify cause, if drug-induced
-039	039	qualifier-synonym~SOS	Actinomycotic infections~Includes: actinomycotic mycetoma; infection by Actinomycetales, such as species of Actinomyces, Actinomadura, Nocardia, Streptomyces; maduromycosis (actinomycotic); schizomycetoma (actinomycotic)
-718.5	718.5	qualifier-synonym~ICE	Ankylosis of joint~Ankylosis of joint (fibrous) (osseous)
+713.5	713.5	qualifier-synonym~ICE	Arthropathy associated with neurological disorders~Charcot's arthropathy associated with diseases classifiable elsewhere; Neuropathic arthritis associated with diseases classifiable elsewhere
 713.5	713.5	qualifier-synonym~ICN	Arthropathy associated with neurological disorders~Code first underlying disease, as: {neuropathic joint disease [Charcot's joints]: NOS (094.0); diabetic (249.6, 250.6); syringomyelic (336.0); tabetic [syphilitic] (094.0)}
-429.2	429.2	qualifier-synonym~ICA	Cardiovascular disease, unspecified~Use additional code to identify presence of arteriosclerosis
-74	74	qualifier-synonym~ICC	Cesarean section and removal of fetus~Code also any synchronous: {hysterectomy (68.3-68.4, 68.6, 68.8); myomectomy (68.29); sterilization (66.31-66.39, 66.63)}
-574	574	qualifier-synonym~ICF	Cholelithiasis~The following fifth-digit subclassification is for use with category 574: {0 without mention of obstruction; 1 with obstruction}
-758	758	qualifier-synonym~ICA	Chromosomal anomalies~Use additional codes for conditions associated with the chromosomal anomalies
-001-139.99	001-139.99	qualifier-synonym~ICN	INFECTIOUS AND PARASITIC DISEASES~Note: Categories for "late effects of infectious and parasitic diseases are to be found at 137-139
-250.90	250.90	qualifier-synonym~ICF	Diabetes with unspecified complication, type II or unspecified type, not stated as uncontrolled~Fifth-digit 0 is for use for type II, adult-onset diabetic patients, even if the patient requires insulin
+595	595	qualifier-synonym~ICA	Cystitis~Use additional code to identify organism, such as Escherichia coli [E. coli] (041.41-041.49)
+595	595	qualifier-synonym~SOS	Cystitis~Excludes: prostatocystitis (601.3)
+239.0	239.0	qualifier-synonym~SOS	Neoplasm of unspecified nature of digestive system~Excludes: anus: {margin (239.2); skin (239.2)}; perianal skin (239.2)
+716.9	716.9	qualifier-synonym~ICE	Arthropathy, unspecified~Arthritis, (acute) (chronic) (subacute); Arthropathy, (acute) (chronic) (subacute); Articular rheumatism, (chronic); Inflammation of joint, NOS
+868	868	qualifier-synonym~ICF	Injury to other intra-abdominal organs~The following fifth-digit subclassification is for use with category 868: {0 unspecified intra-abdominal organ; 1 adrenal gland; 2 bile duct and gallbladder; 3 peritoneum; 4 retroperitoneum; 9 other and multiple intra-abdominal organs}
+538	538	qualifier-synonym~ICA	Gastrointestinal mucositis (ulcerative)~Use additional E code to identify adverse effects of therapy, such as: {antineoplastic and immunosuppressive drugs (E930.7, E933.1); radiation therapy (E879.2)}
 740-759.99	740-759.99	Semantic_Type	Congenital Abnormality
-286.7	286.7	Semantic_Type	Disease or Syndrome
-569.0	569.0	Semantic_Type	Acquired Abnormality
-724.5	724.5	Semantic_Type	Sign or Symptom
-E928.3	E928.3	Semantic_Type	Injury or Poisoning
-348.82	348.82	Semantic_Type	Pathologic Function
-74.99	74.99	Semantic_Type	Therapeutic or Preventive Procedure
-577.2	577.2	Semantic_Type	Anatomical Abnormality
-88.90	88.90	Semantic_Type	Diagnostic Procedure
+039.2	039.2	Semantic_Type	Disease or Syndrome
 239.0	239.0	Semantic_Type	Neoplastic Process
-673.1	673.1	Semantic_Type	Finding
-89.7	89.7	Semantic_Type	Health Care Activity
-990	990	Semantic_Type	Biologic Function
-300.8	300.8	Semantic_Type	Mental or Behavioral Dysfunction
-790.8	790.8	Semantic_Type	Laboratory or Test Result
-V10-V19.99	V10-V19.99	Semantic_Type	Patient or Disabled Group
-V01-V91.99	V01-V91.99	Semantic_Type	Classification
-440	440	root
-414.0	414.0	root
-673.1	673.1	root
-201	201	root
-208	208	root
-386.0	386.0	root
-203.0	203.0	root
-386.1	386.1	root
-633	633	root
-300.8	300.8	root
-410	410	root
-456.2	456.2	root
-655	655	root
-666.3	666.3	root
-942	942	root
-237.7	237.7	root
+977.9	977.9	Semantic_Type	Injury or Poisoning
+459.0	459.0	Semantic_Type	Pathologic Function
+787.0	787.0	Semantic_Type	Sign or Symptom
+54.21	54.21	Semantic_Type	Diagnostic Procedure
+787.4	787.4	Semantic_Type	Finding
+550-553.99	550-553.99	Semantic_Type	Anatomical Abnormality
+54.91	54.91	Semantic_Type	Therapeutic or Preventive Procedure
+551.9	551.9	Semantic_Type	Acquired Abnormality
+595	595	root
+719.9	719.9	root
+716.9	716.9	root
+787.0	787.0	root
+777	777	root
+789.4	789.4	root
 001-999.99	001-999.99	root
-00-99.99	00-99.99	root
-998.3	998.3	root
-E919	E919	root
-E920	E920	root
-258.0	258.0	root
-157	157	root
-646.4	646.4	root
-722.3	722.3	root
-058.8	058.8	root
-V01-V91.99	V01-V91.99	root
-176	176	root
-599.7	599.7	root
-337	337	root
-428	428	root
+789.6	789.6	root
+860-869.99	860-869.99	root
+789.0	789.0	root
+674.1	674.1	root
 740-759.99	740-759.99	parent-count1

--- a/src/test/resources/samples/icd9cm-samples.txt
+++ b/src/test/resources/samples/icd9cm-samples.txt
@@ -1,3 +1,4 @@
+# no version changes so we use the old sample file
 740-759.99	740-759.99	synonym	CONGENITAL ANOMALIES
 740-759.99	740-759.99	term-type	HT
 759.9	759.9	term-type	AB

--- a/src/test/resources/samples/pdq-samples.txt
+++ b/src/test/resources/samples/pdq-samples.txt
@@ -1,3 +1,4 @@
+# no version changes so we use the old sample file
 CDR0000039759	CDR0000039759	synonym	mesna
 CDR0000039759	CDR0000039759	term-type	PT
 CDR0000039759	CDR0000039759	term-type	SY
@@ -10,25 +11,22 @@ CDR0000039759	CDR0000039759	term-type	CHN
 CDR0000039759	CDR0000039759	term-type	NSC
 CDR0000039759	CDR0000039759	term-type	CAS
 CDR0000039759	CDR0000039759	term-type	IND
-CDR0000043436	CDR0000043436	term-type	IS
 CDR0000039152	CDR0000039152	term-type	CU
-CDR0000042838	CDR0000042838	term-type	ACR
-CDR0000041575	CDR0000041575	term-type	DN
-CDR0000038919	CDR0000038919	term-type	PSC
+CDR0000041395	CDR0000041395	term-type	DN
+CDR0000042389	CDR0000042389	term-type	ACR
 100001	100001	term-type	XM
-CDR0000538768	CDR0000538768	term-type	HT
 CDR0000039759	CDR0000039759	qualifier-synonym~LT	Ausobronc~TRD
 CDR0000039759	CDR0000039759	qualifier-synonym~LT	Mesnex~TRD
 CDR0000039759	CDR0000039759	qualifier-synonym~NCI_THESAURUS_CODE	mesna~C192
 CDR0000039759	CDR0000039759	ORIG_STY	Drug/agent
 CDR0000039759	CDR0000039759	PID	2420
 CDR0000039759	CDR0000039759	DATE_LAST_MODIFIED	2006-08-29
-CDR0000537376	CDR0000537376	DATE_FIRST_PUBLISHED	2007-02-16
+CDR0000258127	CDR0000258127	DATE_FIRST_PUBLISHED	2002-10-19
 100001	100001	MAPSETVERSION	2016_07_31
 100001	100001	FROMVSAB	PDQ_2016_07_31
 100001	100001	MAPSETVSAB	PDQ_2016_07_31
 100001	100001	MAPSETSID	100001
-100001	100001	TOVSAB	NCI_2025_06E
+100001	100001	TOVSAB	NCI_2024_06D
 100001	100001	MTH_MAPSETCOMPLEXITY	N_TO_N
 100001	100001	TORSAB	NCI
 100001	100001	MTH_MAPTOCOMPLEXITY	SINGLE SCUI
@@ -39,63 +37,22 @@ CDR0000537376	CDR0000537376	DATE_FIRST_PUBLISHED	2007-02-16
 100001	100001	MTH_MAPFROMEXHAUSTIVE	N
 CDR0000039759	CDR0000039759	Semantic_Type	Organic Chemical
 CDR0000039759	CDR0000039759	Semantic_Type	Pharmacologic Substance
-CDR0000039208	CDR0000039208	Semantic_Type	Nucleic Acid, Nucleoside, or Nucleotide
-CDR0000537376	CDR0000537376	Semantic_Type	Biologically Active Substance
-CDR0000459776	CDR0000459776	Semantic_Type	Amino Acid, Peptide, or Protein
-CDR0000712834	CDR0000712834	Semantic_Type	Indicator, Reagent, or Diagnostic Aid
-CDR0000039131	CDR0000039131	Semantic_Type	Antibiotic
-CDR0000040467	CDR0000040467	Semantic_Type	Immunologic Factor
-CDR0000042000	CDR0000042000	Semantic_Type	Inorganic Chemical
-CDR0000039141	CDR0000039141	Semantic_Type	Hazardous or Poisonous Substance
-CDR0000555364	CDR0000555364	Semantic_Type	Disease or Syndrome
-CDR0000039294	CDR0000039294	Semantic_Type	Hormone
-CDR0000039737	CDR0000039737	Semantic_Type	Vitamin
-CDR0000041146	CDR0000041146	Semantic_Type	Enzyme
-CDR0000529382	CDR0000529382	Semantic_Type	Neoplastic Process
-CDR0000042815	CDR0000042815	Semantic_Type	Diagnostic Procedure
-CDR0000038990	CDR0000038990	Semantic_Type	Therapeutic or Preventive Procedure
 CDR0000258127	CDR0000258127	Semantic_Type	Classification
 CDR0000774885	CDR0000774885	Semantic_Type	Pathologic Function
 CDR0000041384	CDR0000041384	Semantic_Type	Injury or Poisoning
-CDR0000551693	CDR0000551693	Semantic_Type	Congenital Abnormality
-CDR0000636738	CDR0000636738	Semantic_Type	Anatomical Abnormality
-CDR0000355797	CDR0000355797	Semantic_Type	Medical Device
-CDR0000038919	CDR0000038919	Semantic_Type	Laboratory or Test Result
-CDR0000716087	CDR0000716087	Semantic_Type	Food
-CDR0000258213	CDR0000258213	Semantic_Type	Plant
-CDR0000038724	CDR0000038724	Semantic_Type	Element, Ion, or Isotope
+CDR0000256156	CDR0000256156	Semantic_Type	Disease or Syndrome
+CDR0000682551	CDR0000682551	Semantic_Type	Anatomical Abnormality
 CDR0000041395	CDR0000041395	Semantic_Type	Sign or Symptom
-CDR0000752030	CDR0000752030	Semantic_Type	Virus
-CDR0000715259	CDR0000715259	Semantic_Type	Biomedical or Dental Material
-CDR0000510282	CDR0000510282	Semantic_Type	Substance
-CDR0000041004	CDR0000041004	Semantic_Type	Cell
-CDR0000472005	CDR0000472005	Semantic_Type	Finding
-CDR0000256087	CDR0000256087	Semantic_Type	Health Care Activity
-CDR0000542519	CDR0000542519	Semantic_Type	Laboratory Procedure
-CDR0000040050	CDR0000040050	Semantic_Type	Temporal Concept
+CDR0000482229	CDR0000482229	Semantic_Type	Neoplastic Process
+CDR0000042814	CDR0000042814	Semantic_Type	Diagnostic Procedure
+CDR0000695416	CDR0000695416	Semantic_Type	Antibiotic
 CDR0000258128	CDR0000258128	Semantic_Type	Research Activity
-CDR0000038900	CDR0000038900	Semantic_Type	Clinical Attribute
-CDR0000038911	CDR0000038911	Semantic_Type	Quantitative Concept
-CDR0000041858	CDR0000041858	Semantic_Type	Drug Delivery Device
-CDR0000043329	CDR0000043329	Semantic_Type	Biomedical Occupation or Discipline
-CDR0000741836	CDR0000741836	Semantic_Type	Clinical Drug
-CDR0000043534	CDR0000043534	Semantic_Type	Gene or Genome
-CDR0000037800	CDR0000037800	Semantic_Type	Bacterium
-CDR0000473030	CDR0000473030	Semantic_Type	Chemical Viewed Functionally
-CDR0000041209	CDR0000041209	Semantic_Type	Mental or Behavioral Dysfunction
+CDR0000042389	CDR0000042389	Semantic_Type	Therapeutic or Preventive Procedure
 100001	100001	Semantic_Type	Intellectual Product
-CDR0000613516	CDR0000613516	Semantic_Type	Population Group
 MTHU000001	MTHU000001	Semantic_Type	Conceptual Entity
-CDR0000039759	CDR0000039759	DEFINITION	A sulfhydryl compound that is used to reduce the incidence of hemorrhagic cystitis associated with certain chemotherapeutic agents. Mesna is converted to a free thiol compound in the kidney, where it binds to and inactivates acrolein and other urotoxic metabolites of ifosfamide and cyclophosphamide, thereby reducing their toxic effects on the urinary tract during urinary excretion. ("http://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI%20Thesaurus&code=C192" NCI Thesaurus)
+CDR0000039759	CDR0000039759	DEFINITION	A sulfhydryl compound that is used to reduce the incidence of hemorrhagic cystitis associated with certain chemotherapeutic agents. Mesna is converted to a free thiol compound in the kidney, where it binds to and inactivates acrolein and other urotoxic metabolites of ifosfamide and cyclophosphamide, thereby reducing their toxic effects on the urinary tract during urinary excretion. Check for "http://www.cancer.gov/Search/ClinicalTrialsLink.aspx?id=39759&idtype=1" active clinical trials using this agent. ("http://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI%20Thesaurus&code=C192" NCI Thesaurus)
 CDR0000258127	CDR0000258127	root
 CDR0000256166	CDR0000256166	root
-CDR0000641624	CDR0000641624	root
-CDR0000701772	CDR0000701772	root
-CDR0000256087	CDR0000256087	root
-CDR0000258128	CDR0000258128	root
-CDR0000041429	CDR0000041429	root
 CDR0000256085	CDR0000256085	root
 CDR0000256171	CDR0000256171	root
-MTHU000001	MTHU000001	root
 CDR0000039759	CDR0000039759	parent-count1
-CDR0000529382	CDR0000529382	parent-count2


### PR DESCRIPTION
reverts the sampling test data for PDQ, ICD10, and ICD9CM because their versions didn't change with the test data