### PR TITLE
Pva/evsrestapi 720 investigate chebi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,15 +96,15 @@ dependencies {
   // 6.4.0 contains a vulnerability; 6.9.4 is the version co-packaged with HAPI FHIR that fixes it.
   // These overrides can only be removed by upgrading to HAPI FHIR 8.x (a major breaking-change migration).
   implementation "org.fhir:ucum:1.0.9"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.convertors:6.9.4"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.dstu2:6.9.4"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.dstu2016may:6.9.4"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.dstu3:6.9.4"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r4:6.9.4"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r4b:6.9.4"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r5:6.9.4"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.utilities:6.9.4"
-  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.validation:6.9.4"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.convertors:6.9.7"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.dstu2:6.9.7"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.dstu2016may:6.9.7"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.dstu3:6.9.7"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r4:6.9.7"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r4b:6.9.7"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.r5:6.9.7"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.utilities:6.9.7"
+  implementation "ca.uhn.hapi.fhir:org.hl7.fhir.validation:6.9.7"
 
   //implementation "org.springframework.data:spring-data-elasticsearch:4.2.12"
   implementation "org.opensearch.client:spring-data-opensearch-starter:1.7.1"
@@ -115,7 +115,7 @@ dependencies {
 
   // other explicit vulnerability overrides
   implementation "org.apache.commons:commons-lang3:3.18.0"
-  implementation "org.apache.tomcat.embed:tomcat-embed-core:10.1.54"
+  implementation "org.apache.tomcat.embed:tomcat-embed-core:10.1.55"
   implementation "org.apache.thrift:libthrift:0.23.0"
   implementation "org.thymeleaf:thymeleaf:3.1.5.RELEASE"
   implementation "org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE"

--- a/src/main/bin/reindex.sh
+++ b/src/main/bin/reindex.sh
@@ -575,24 +575,29 @@ fi
 /bin/rm -rf /tmp/x.$$.log
 
 # Reconcile mappings after loading terminologies
-export EVS_SERVER_PORT="8083"
-echo "    Generate mapping indexes"
-echo "      java --add-opens=java.base/java.io=ALL-UNNAMED $local -Xmx4096M -jar $jar --terminology mapping"
-java --add-opens=java.base/java.io=ALL-UNNAMED $local -XX:+ExitOnOutOfMemoryError -Xmx4096M -jar $jar --terminology mapping
-if [[ $? -ne 0 ]]; then
-    echo "ERROR: unexpected error building mapping indexes"
-    exit 1
-fi
-
-# Verify that max_result_window on evs_mappings is set to 3000000
-if [[ `curl -s "$ES_SCHEME://$ES_HOST:$ES_PORT/evs_mappings/_settings" | grep -c max_result_window` -eq 0 ]]; then
-    # Set the indexes to have a larger max_result_window
-    echo "  Set max result window to 300000 for evs_mappings"
-    curl -s -X PUT "$ES_SCHEME://$ES_HOST:$ES_PORT/evs_mappings/_settings" \
-         -H "Content-type: application/json" -d '{ "index" : { "max_result_window" : 300000 } }' >> /dev/null
+# Skip it for targeted reindexing.
+if [[ $terminologyOverride ]]; then
+    echo "    SKIP mapping indexes (targeted reindex of $terminologyOverride)"
+else
+    export EVS_SERVER_PORT="8083"
+    echo "    Generate mapping indexes"
+    echo "      java --add-opens=java.base/java.io=ALL-UNNAMED $local -Xmx4096M -jar $jar --terminology mapping"
+    java --add-opens=java.base/java.io=ALL-UNNAMED $local -XX:+ExitOnOutOfMemoryError -Xmx4096M -jar $jar --terminology mapping
     if [[ $? -ne 0 ]]; then
-        echo "ERROR: unexpected error setting max_result_window for evs_mappings"
+        echo "ERROR: unexpected error building mapping indexes"
         exit 1
+    fi
+
+    # Verify that max_result_window on evs_mappings is set to 3000000
+    if [[ `curl -s "$ES_SCHEME://$ES_HOST:$ES_PORT/evs_mappings/_settings" | grep -c max_result_window` -eq 0 ]]; then
+        # Set the indexes to have a larger max_result_window
+        echo "  Set max result window to 300000 for evs_mappings"
+        curl -s -X PUT "$ES_SCHEME://$ES_HOST:$ES_PORT/evs_mappings/_settings" \
+             -H "Content-type: application/json" -d '{ "index" : { "max_result_window" : 300000 } }' >> /dev/null
+        if [[ $? -ne 0 ]]; then
+            echo "ERROR: unexpected error setting max_result_window for evs_mappings"
+            exit 1
+        fi
     fi
 fi
 

--- a/src/main/java/gov/nih/nci/evs/api/service/AbstractGraphLoadServiceImpl.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/AbstractGraphLoadServiceImpl.java
@@ -146,7 +146,7 @@ public abstract class AbstractGraphLoadServiceImpl extends BaseLoaderService {
     logger.info("Load all associations");
     hierarchy.setAssociationMap(
         sparqlQueryManagerService.getAssociationsForAllCodes(terminology, false));
-    logger.info("Load all inverse roles");
+    logger.info("Load all inverse associations");
     hierarchy.setInverseAssociationMap(
         sparqlQueryManagerService.getAssociationsForAllCodes(terminology, true));
 
@@ -606,7 +606,8 @@ public abstract class AbstractGraphLoadServiceImpl extends BaseLoaderService {
         continue;
       }
 
-      // get the subset and concept that the new subset is a part of i.e. pediatric subset part of
+      // get the subset and concept that the new subset is a part of i.e. pediatric
+      // subset part of
       // ncit subset
       Map<String, String> newSubsets = terminology.getMetadata().getExtraSubsets();
       Concept parentSubset = new Concept();
@@ -688,7 +689,8 @@ public abstract class AbstractGraphLoadServiceImpl extends BaseLoaderService {
         inverseAssoc.setRelatedCode(subsetMember.getCode());
         inverseAssoc.setRelatedName(subsetMember.getName());
         subsetConcept.getInverseAssociations().add(inverseAssoc);
-        // index subsetMember (but only if the member is not also the subset concept itself)
+        // index subsetMember (but only if the member is not also the subset concept
+        // itself)
         if (!subsetMember.getCode().equals(subsetConcept.getCode())) {
           operationsService.update(
               subsetMember.getCode(), subsetMember, terminology.getIndexName(), Concept.class);
@@ -1179,7 +1181,8 @@ The browser links each mapped concept to that concept's page in the current prod
 
         historyItem.put("replacementCode", replacementCode);
 
-        // create history entry for the replacement concept if it isn't merging with itself
+        // create history entry for the replacement concept if it isn't merging with
+        // itself
         if (!replacementCode.equals(code)) {
 
           List<Map<String, String>> replacementConceptHistory = new ArrayList<>();
@@ -1216,10 +1219,13 @@ The browser links each mapped concept to that concept's page in the current prod
       String newHistoryVersion)
       throws Exception {
 
-    // Update history for "ncit" monthly when it gets revisitied to double check latest versions
-    // Skip this for other terminologies, for cases where an updated cumulative history file has
+    // Update history for "ncit" monthly when it gets revisitied to double check
+    // latest versions
+    // Skip this for other terminologies, for cases where an updated cumulative
+    // history file has
     // already been processed
-    // or in cases where the cumulative history for this version is unable to be found
+    // or in cases where the cumulative history for this version is unable to be
+    // found
     if (!terminology.getTerminology().equals("ncit")
         || newHistoryVersion == null
         || newHistoryVersion.isEmpty()) {

--- a/src/main/resources/sparql-queries.properties
+++ b/src/main/resources/sparql-queries.properties
@@ -399,6 +399,12 @@ associations.all=SELECT ?concept ?conceptCode ?conceptLabel ?relationship ?relat
   } \
 }
 
+# ChEBI 247 has no code-bearing class-to-class annotation associations, so this
+# ChEBI-only setup query returns no rows instead of spending minutes on the
+# generic all-associations query. If future ChEBI data adds these associations,
+# comment/delete the line below to fall back to associations.all.
+associations.all.chebi=SELECT ?concept ?conceptCode ?conceptLabel ?relationship ?relationshipCode ?relationshipLabel ?relatedConcept ?relatedConceptCode ?relatedConceptLabel WHERE { FILTER(false) }
+
 # nothing optional for NCIt.
 associations.all.ncit=SELECT ?conceptCode ?conceptLabel ?relationshipCode ?relationshipLabel ?relatedConceptCode ?relatedConceptLabel \
 { GRAPH <#{namedGraph}> \

--- a/src/main/resources/sparql-queries.properties
+++ b/src/main/resources/sparql-queries.properties
@@ -179,6 +179,34 @@ WHERE { \
 } \
 ORDER BY ?conceptCode ?propertyCode ?propertyLabel
 
+properties.batch.chebi=SELECT DISTINCT ?conceptCode ?property ?propertyCode ?propertyLabel ?propertyValue \
+WHERE { \
+  VALUES ?conceptCode \
+  { \
+    #{valuesClause} \
+  } \
+  { GRAPH <#{namedGraph}> \
+    { \
+      { \
+        ?x #{codeCode} ?conceptCode . \
+        ?x owl:deprecated ?propertyValue . \
+        BIND(<http://www.w3.org/2002/07/owl#deprecated> AS ?property) \
+      } \
+      UNION \
+      { \
+        ?x a owl:Class . \
+        ?x #{codeCode} ?conceptCode . \
+        ?x ?property ?propertyValue . \
+        ?property a owl:AnnotationProperty . \
+        OPTIONAL { ?property #{preferredNameCode} ?propertyLabel } . \
+        OPTIONAL { ?property #{codeCode} ?propertyCode } . \
+        FILTER NOT EXISTS { ?property rdfs:range xml:anyURI } \
+      } \
+    } \
+  } \
+} \
+ORDER BY ?conceptCode ?propertyCode ?propertyLabel
+
 
 # ORDER by is important here because we need all the axiom parts together
 axioms=SELECT ?axiom ?axiomProperty ?axiomValue \
@@ -1047,6 +1075,11 @@ disjoint.with.batch=SELECT ?conceptCode ?relatedConcept ?relatedConceptCode ?rel
   } \
 }
 #ORDER BY ?conceptCode
+
+# ChEBI 247 has no owl:disjointWith triples, so this ChEBI override returns
+# no rows instead of running the generic disjoint query for every batch. If a
+# future ChEBI release adds owl:disjointWith, delete this to fall back to disjoint.with.batch.
+disjoint.with.batch.chebi=SELECT ?conceptCode ?relatedConcept ?relatedConceptCode ?relatedConceptLabel WHERE { FILTER(false) }
 
 # (1) owl:Class|rdfs:subClassOf|owl:Class
 # (2) owl:Class|owl:equivalentClass|owl:Class|owl:intersectionOf|owl:Class

--- a/src/test/java/gov/nih/nci/evs/api/controller/ChebiSampleTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/ChebiSampleTest.java
@@ -123,4 +123,29 @@ public class ChebiSampleTest extends SampleTest {
     assertThat(concept.getTerminology()).isEqualTo("chebi");
     assertThat(concept.getActive()).isTrue();
   }
+
+  /**
+   * Test ChEBI relationship buckets.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testRelationshipBuckets() throws Exception {
+
+    final String url =
+        "/api/v1/concept/chebi/CHEBI:100?include=roles,associations,inverseAssociations,disjointWith";
+    log.info("Testing url - " + url);
+    final MvcResult result = testMvc.perform(get(url)).andExpect(status().isOk()).andReturn();
+    final String content = result.getResponse().getContentAsString();
+    log.info(" content = " + content);
+    final Concept concept = ThreadLocalMapper.get().readValue(content, Concept.class);
+
+    assertThat(concept).isNotNull();
+    assertThat(concept.getCode()).isEqualTo("CHEBI:100");
+    assertThat(concept.getRoles()).extracting(role -> role.getCode()).contains("has_role");
+    assertThat(concept.getRoles()).extracting(role -> role.getCode()).contains("is_enantiomer_of");
+    assertThat(concept.getAssociations()).isEmpty();
+    assertThat(concept.getInverseAssociations()).isEmpty();
+    assertThat(concept.getDisjointWith()).isEmpty();
+  }
 }


### PR DESCRIPTION
Added ChEBI-specific SPARQL overrides for the slow property batch, associations, and disjoint with queries. Direct ChEBI batch comparisons showed identical results with the override running much faster, and post-reindex ChEBI tests passed.

Also tweaked the targeted terminology reindex flag in reindex.sh to skip mapping reloads.

The changes in AbstractGraphLoaderServiceImpl are just spotless being weird.