### PR TITLE
Pva/evsrestapi 440 log details on es call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ clean:
 build:
 	./gradlew clean spotlessApply build spotbugsMain spotbugsTest -x test -x zipFile
 
-run:
-	java -Dspring.profiles.active=local -jar build/libs/evsrestapi*.jar
+run: build
+	java -Dspring.profiles.active=local -jar build/libs/evsrestapi*.war
 
 test:
 	./gradlew spotlessCheck -x test 

--- a/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptor.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptor.java
@@ -84,16 +84,21 @@ final class EvsOpenSearchRequestLoggingInterceptor implements HttpRequestInterce
     }
 
     final ContentType contentType = ContentType.get(entity);
+    // OpenSearch search payloads should be JSON or NDJSON. If another media type appears, do not
+    // decode or rebuild it just for logging; leave the original entity untouched.
     if (!isLoggableContentType(contentType)) {
       return "<payload not logged: content type " + contentType.getMimeType() + ">";
     }
 
+    // OpenSearch JSON is normally UTF-8. Honor an explicit charset when present, but default to
+    // UTF-8 when Apache's entity metadata does not include one.
     final Charset charset =
         contentType == null || contentType.getCharset() == null
             ? StandardCharsets.UTF_8
             : contentType.getCharset();
 
-    // EntityUtils reads and closes the original entity content stream.
+    // EntityUtils reads and closes the original entity content stream. Keep the raw bytes so the
+    // outgoing request can be restored byte-for-byte, even if the logged text is truncated.
     final byte[] payloadBytes = EntityUtils.toByteArray(entity);
     final String payload = new String(payloadBytes, charset);
 
@@ -108,6 +113,7 @@ final class EvsOpenSearchRequestLoggingInterceptor implements HttpRequestInterce
     }
     entityRequest.setEntity(replacement);
 
+    // Only the log message is truncated. The replacement entity above contains the full payload.
     return truncatePayload(payload);
   }
 
@@ -118,6 +124,8 @@ final class EvsOpenSearchRequestLoggingInterceptor implements HttpRequestInterce
    * @return {@code true} if the payload should be decoded and logged
    */
   private boolean isLoggableContentType(final ContentType contentType) {
+    // Missing content type is allowed because Spring/OpenSearch callers can still provide a normal
+    // JSON body without Apache metadata; in that case getPayload decodes as UTF-8.
     if (contentType == null) {
       return true;
     }
@@ -137,6 +145,7 @@ final class EvsOpenSearchRequestLoggingInterceptor implements HttpRequestInterce
       return payload;
     }
 
+    // Keep the truncation marker explicit so a copied log body is not mistaken for the full query.
     return payload.substring(0, MAX_LOGGED_PAYLOAD_LENGTH)
         + "\n<... payload truncated after "
         + MAX_LOGGED_PAYLOAD_LENGTH

--- a/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptor.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptor.java
@@ -1,0 +1,219 @@
+package gov.nih.nci.evs.api.configuration;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Logs the actual low-level OpenSearch HTTP request sent by the REST client.
+ *
+ * <p>This interceptor runs after Spring Data OpenSearch has converted a {@code Query} into an HTTP
+ * request, so it sees the request that can be replayed outside Java: method, URL, query-string
+ * parameters, index path, and serialized JSON payload.
+ */
+final class EvsOpenSearchRequestLoggingInterceptor implements HttpRequestInterceptor {
+
+  /** The Constant logger. */
+  private static final Logger logger = LoggerFactory.getLogger(EvsOpenSearchRestTemplate.class);
+
+  /** The maximum number of payload characters to write to the log. */
+  private static final int MAX_LOGGED_PAYLOAD_LENGTH = 100_000;
+
+  /** The OpenSearch bulk/msearch newline-delimited JSON media type. */
+  private static final String NDJSON_MIME_TYPE = "application/x-ndjson";
+
+  /* see superclass */
+  @Override
+  public void process(final HttpRequest request, final HttpContext context)
+      throws HttpException, IOException {
+    // This interceptor is invoked for every OpenSearch request. Keep the normal INFO path cheap.
+    if (!logger.isDebugEnabled()) {
+      return;
+    }
+
+    // Request URI is the path and query string the low-level REST client is about to send.
+    final String requestUri = request.getRequestLine().getUri();
+    final String requestPath = getRequestPath(requestUri);
+    final String payload = getPayload(request);
+
+    logger.debug(
+        "opensearch request:"
+            + "\n  method = {}"
+            + "\n  url = {}"
+            + "\n  parameters = {}"
+            + "\n  index = {}"
+            + "\n  payload =\n{}",
+        request.getRequestLine().getMethod(),
+        getRequestUrl(requestUri, context),
+        getRequestParameters(requestUri),
+        getRequestIndex(requestPath),
+        payload);
+  }
+
+  /**
+   * Get the request payload while replacing the consumed entity so the request can still be sent.
+   *
+   * <p>Reading an Apache HTTP entity consumes its stream. After logging, we must put an equivalent
+   * entity back on the request; otherwise OpenSearch would receive an empty body.
+   *
+   * @param request the request
+   * @return the payload text to log, or {@code <none>} when there is no body
+   * @throws IOException if the entity cannot be read
+   */
+  private String getPayload(final HttpRequest request) throws IOException {
+    if (!(request instanceof HttpEntityEnclosingRequest entityRequest)) {
+      return "<none>";
+    }
+
+    final HttpEntity entity = entityRequest.getEntity();
+    if (entity == null) {
+      return "<none>";
+    }
+
+    final ContentType contentType = ContentType.get(entity);
+    if (!isLoggableContentType(contentType)) {
+      return "<payload not logged: content type " + contentType.getMimeType() + ">";
+    }
+
+    final Charset charset =
+        contentType == null || contentType.getCharset() == null
+            ? StandardCharsets.UTF_8
+            : contentType.getCharset();
+
+    // EntityUtils reads and closes the original entity content stream.
+    final byte[] payloadBytes = EntityUtils.toByteArray(entity);
+    final String payload = new String(payloadBytes, charset);
+
+    // Replace the consumed entity with the full payload and headers before the request continues.
+    final ByteArrayEntity replacement = new ByteArrayEntity(payloadBytes);
+    if (entity.getContentType() != null) {
+      replacement.setContentType(entity.getContentType());
+    }
+    replacement.setChunked(entity.isChunked());
+    if (entity.getContentEncoding() != null) {
+      replacement.setContentEncoding(entity.getContentEncoding());
+    }
+    entityRequest.setEntity(replacement);
+
+    return truncatePayload(payload);
+  }
+
+  /**
+   * Determine whether a request entity can be safely decoded as text for logging.
+   *
+   * @param contentType the entity content type
+   * @return {@code true} if the payload should be decoded and logged
+   */
+  private boolean isLoggableContentType(final ContentType contentType) {
+    if (contentType == null) {
+      return true;
+    }
+
+    return ContentType.APPLICATION_JSON.getMimeType().equalsIgnoreCase(contentType.getMimeType())
+        || NDJSON_MIME_TYPE.equalsIgnoreCase(contentType.getMimeType());
+  }
+
+  /**
+   * Limit the payload text written to the log while leaving the actual request body unchanged.
+   *
+   * @param payload the decoded payload
+   * @return the payload text to log
+   */
+  private String truncatePayload(final String payload) {
+    if (payload.length() <= MAX_LOGGED_PAYLOAD_LENGTH) {
+      return payload;
+    }
+
+    return payload.substring(0, MAX_LOGGED_PAYLOAD_LENGTH)
+        + "\n<... payload truncated after "
+        + MAX_LOGGED_PAYLOAD_LENGTH
+        + " characters>";
+  }
+
+  /**
+   * Get the full request URL.
+   *
+   * <p>The Apache request line usually contains only a relative URI like {@code /index/_search}, so
+   * the target host from the HTTP context is used to make the logged URL directly replayable.
+   *
+   * @param requestUri the URI from the request line
+   * @param context the request context
+   * @return the full request URL when the target host is known, otherwise the request URI
+   */
+  private String getRequestUrl(final String requestUri, final HttpContext context) {
+    if (requestUri.startsWith("http://") || requestUri.startsWith("https://")) {
+      return requestUri;
+    }
+
+    final HttpHost targetHost = HttpCoreContext.adapt(context).getTargetHost();
+    return targetHost == null ? requestUri : targetHost.toURI() + requestUri;
+  }
+
+  /**
+   * Get the query-string parameters from the request URI.
+   *
+   * @param requestUri the URI from the request line
+   * @return the raw query-string parameters, or {@code <none>} when absent
+   */
+  private String getRequestParameters(final String requestUri) {
+    final int queryIndex = requestUri.indexOf('?');
+    if (queryIndex < 0 || queryIndex == requestUri.length() - 1) {
+      return "<none>";
+    }
+    return requestUri.substring(queryIndex + 1);
+  }
+
+  /**
+   * Get the path portion from a relative or absolute request URI.
+   *
+   * @param requestUri the URI from the request line
+   * @return the request path
+   */
+  private String getRequestPath(final String requestUri) {
+    int pathIndex = 0;
+    final int schemeIndex = requestUri.indexOf("://");
+    if (schemeIndex >= 0) {
+      pathIndex = requestUri.indexOf('/', schemeIndex + 3);
+      if (pathIndex < 0) {
+        return "/";
+      }
+    }
+
+    final int queryIndex = requestUri.indexOf('?', pathIndex);
+    return queryIndex < 0
+        ? requestUri.substring(pathIndex)
+        : requestUri.substring(pathIndex, queryIndex);
+  }
+
+  /**
+   * Extract the first path segment as the index when the request path is index-scoped.
+   *
+   * <p>Search requests are typically {@code /index/_search}; cluster APIs such as {@code
+   * /_cluster/health} do not have an index and are reported as {@code <none>}.
+   *
+   * @param requestPath the path portion of the request URI
+   * @return the index path segment, or {@code <none>} when the request is not index-scoped
+   */
+  private String getRequestIndex(final String requestPath) {
+    final String normalizedPath = requestPath.replaceFirst("^/+", "");
+    if (normalizedPath.isBlank()) {
+      return "<none>";
+    }
+
+    final String firstSegment = normalizedPath.split("/", 2)[0];
+    return firstSegment.startsWith("_") ? "<none>" : firstSegment;
+  }
+}

--- a/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptor.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptor.java
@@ -3,7 +3,6 @@ package gov.nih.nci.evs.api.configuration;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;

--- a/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptor.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptor.java
@@ -3,6 +3,7 @@ package gov.nih.nci.evs.api.configuration;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpException;
@@ -50,15 +51,10 @@ final class EvsOpenSearchRequestLoggingInterceptor implements HttpRequestInterce
     final String payload = getPayload(request);
 
     logger.debug(
-        "opensearch request:"
-            + "\n  method = {}"
-            + "\n  url = {}"
-            + "\n  parameters = {}"
-            + "\n  index = {}"
-            + "\n  payload =\n{}",
+        "opensearch request = " + "\n    {} {}" + "\n    {} = {}",
         request.getRequestLine().getMethod(),
         getRequestUrl(requestUri, context),
-        getRequestParameters(requestUri),
+        // getRequestParameters(requestUri),
         getRequestIndex(requestPath),
         payload);
   }
@@ -177,6 +173,7 @@ final class EvsOpenSearchRequestLoggingInterceptor implements HttpRequestInterce
    * @param requestUri the URI from the request line
    * @return the raw query-string parameters, or {@code <none>} when absent
    */
+  @SuppressWarnings("unused")
   private String getRequestParameters(final String requestUri) {
     final int queryIndex = requestUri.indexOf('?');
     if (queryIndex < 0 || queryIndex == requestUri.length() - 1) {

--- a/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRestTemplate.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRestTemplate.java
@@ -35,8 +35,12 @@ public class EvsOpenSearchRestTemplate extends OpenSearchRestTemplate {
   @Override
   public <T> SearchHits<T> search(
       final Query query, final Class<T> clazz, final IndexCoordinates index) {
-    if (logger.isDebugEnabled() && ((NativeSearchQuery) query).getQuery() != null) {
-      logger.debug("  opensearch query = \n" + ((NativeSearchQuery) query).getQuery());
+    // Keep the original Spring Data query log for NativeSearchQuery callers. The HTTP interceptor
+    // logs the full replayable OpenSearch request after this query has been serialized.
+    if (logger.isDebugEnabled()
+        && query instanceof NativeSearchQuery nativeSearchQuery
+        && nativeSearchQuery.getQuery() != null) {
+      logger.debug("  opensearch query = \n{}", nativeSearchQuery.getQuery());
     }
 
     return super.search(query, clazz, index);

--- a/src/main/java/gov/nih/nci/evs/api/configuration/OpensearchConfiguration.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/OpensearchConfiguration.java
@@ -53,7 +53,12 @@ public class OpensearchConfiguration {
     return new RestHighLevelClient(
         RestClient.builder(new HttpHost(osHost, osPort, osScheme))
             .setRequestConfigCallback(
-                builder -> builder.setConnectTimeout(timeout).setSocketTimeout(timeout)));
+                builder -> builder.setConnectTimeout(timeout).setSocketTimeout(timeout))
+            // This hooks the HTTP layer, after Spring Data has serialized Query objects into
+            // replayable OpenSearch REST requests.
+            .setHttpClientConfigCallback(
+                builder ->
+                    builder.addInterceptorLast(new EvsOpenSearchRequestLoggingInterceptor())));
 
     // Alternate:
     // ClientConfiguration clientConfiguration =

--- a/src/main/java/gov/nih/nci/evs/api/configuration/OpensearchConfiguration.java
+++ b/src/main/java/gov/nih/nci/evs/api/configuration/OpensearchConfiguration.java
@@ -5,6 +5,7 @@ package gov.nih.nci.evs.api.configuration;
 import org.apache.http.HttpHost;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.data.client.orhlc.OpenSearchRestTemplate;
 import org.opensearch.data.core.OpenSearchOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +76,7 @@ public class OpensearchConfiguration {
   @SuppressWarnings("resource")
   @Bean
   public OpenSearchOperations openSearchOperations() {
-    return new EvsOpenSearchRestTemplate(client());
+    //    return new EvsOpenSearchRestTemplate(client());
+    return new OpenSearchRestTemplate(client());
   }
 }

--- a/src/test/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptorTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptorTest.java
@@ -23,7 +23,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.LoggerFactory;
 
-/** Unit tests for {@link EvsOpenSearchRequestLoggingInterceptor}. */
+/**
+ * Unit tests for {@link EvsOpenSearchRequestLoggingInterceptor}.
+ *
+ * <p>These tests avoid Spring context startup and exercise the Apache HTTP request objects
+ * directly, which is the layer where the interceptor reads, logs, and restores outgoing OpenSearch
+ * requests.
+ */
 @ResourceLock("EvsOpenSearchRestTemplateLogger")
 class EvsOpenSearchRequestLoggingInterceptorTest {
 
@@ -45,6 +51,9 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
     logger = (Logger) LoggerFactory.getLogger(EvsOpenSearchRestTemplate.class);
     originalLevel = logger.getLevel();
     originalAdditive = logger.isAdditive();
+
+    // The interceptor is DEBUG-gated. Flip only this logger for the test and make it non-additive
+    // so the captured request log does not also go to the root console appender.
     logger.setLevel(Level.DEBUG);
     logger.setAdditive(false);
 
@@ -56,6 +65,7 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
   /** Restore logger state after each test. */
   @AfterEach
   void cleanup() {
+    // Logger configuration is JVM-global, so every test restores the original state it changed.
     logger.detachAppender(appender);
     appender.stop();
     logger.setLevel(originalLevel);
@@ -68,6 +78,7 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
    * @return the logged request message
    */
   private String getLoggedMessage() {
+    // Each interceptor invocation should produce exactly one request log entry.
     assertEquals(1, appender.list.size());
     return appender.list.get(0).getFormattedMessage();
   }

--- a/src/test/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptorTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptorTest.java
@@ -1,0 +1,234 @@
+package gov.nih.nci.evs.api.configuration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.nio.charset.StandardCharsets;
+import org.apache.http.HttpHost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.message.BasicHttpEntityEnclosingRequest;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.protocol.HttpCoreContext;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+/** Unit tests for {@link EvsOpenSearchRequestLoggingInterceptor}. */
+class EvsOpenSearchRequestLoggingInterceptorTest {
+
+  /** The logger used by the interceptor. */
+  private Logger logger;
+
+  /** The original logger level. */
+  private Level originalLevel;
+
+  /** The original logger additive setting. */
+  private boolean originalAdditive;
+
+  /** The appender used to inspect log events. */
+  private ListAppender<ILoggingEvent> appender;
+
+  /** Configure in-memory logging for each test. */
+  @BeforeEach
+  void setup() {
+    logger = (Logger) LoggerFactory.getLogger(EvsOpenSearchRestTemplate.class);
+    originalLevel = logger.getLevel();
+    originalAdditive = logger.isAdditive();
+    logger.setLevel(Level.DEBUG);
+    logger.setAdditive(false);
+
+    appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+  }
+
+  /** Restore logger state after each test. */
+  @AfterEach
+  void cleanup() {
+    logger.detachAppender(appender);
+    appender.stop();
+    logger.setLevel(originalLevel);
+    logger.setAdditive(originalAdditive);
+  }
+
+  /** Test that search requests log the actual request details and preserve the payload. */
+  @Test
+  void logsSearchRequestDetailsAndPreservesPayload() throws Exception {
+    final String payload =
+        """
+        {
+          "query": {
+            "match": {
+              "user.id": "kimchy"
+            }
+          },
+          "fields": [
+            "user.id",
+            "http.response.*",
+            {
+              "field": "@timestamp",
+              "format": "epoch_millis"
+            }
+          ],
+          "_source": false
+        }
+        """;
+    final BasicHttpEntityEnclosingRequest request =
+        new BasicHttpEntityEnclosingRequest(
+            "POST", "/my-index-000001/_search?typed_keys=true&search_type=query_then_fetch");
+    request.setEntity(
+        new StringEntity(
+            payload, ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8)));
+
+    final HttpCoreContext context = HttpCoreContext.create();
+    context.setTargetHost(new HttpHost("localhost", 9201, "http"));
+
+    new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
+
+    final String logMessage = appender.list.get(0).getFormattedMessage();
+    assertTrue(logMessage.contains("method = POST"));
+    assertTrue(
+        logMessage.contains(
+            "url = http://localhost:9201/my-index-000001/_search?"
+                + "typed_keys=true&search_type=query_then_fetch"));
+    assertTrue(logMessage.contains("parameters = typed_keys=true&search_type=query_then_fetch"));
+    assertTrue(logMessage.contains("index = my-index-000001"));
+    assertTrue(logMessage.contains("\"fields\""));
+    assertTrue(logMessage.contains("\"user.id\""));
+    assertTrue(logMessage.contains("\"_source\": false"));
+    assertEquals(payload, EntityUtils.toString(request.getEntity(), StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Test that payload logging preserves entity metadata when replacing the consumed request body.
+   *
+   * <p>{@link EvsOpenSearchRequestLoggingInterceptor} reads the request entity so it can log the
+   * serialized OpenSearch payload. That read consumes the original entity, so the interceptor
+   * replaces it before the request continues. This test documents that the replacement keeps the
+   * same body and HTTP entity metadata needed to send it as JSON.
+   */
+  @Test
+  void preservesPayloadEntityMetadataAfterLogging() throws Exception {
+    final String payload = "{\"query\":{\"match_all\":{}}}";
+    final BasicHttpEntityEnclosingRequest request =
+        new BasicHttpEntityEnclosingRequest("POST", "/my-index/_search");
+    final StringEntity entity =
+        new StringEntity(payload, ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8));
+    entity.setContentEncoding("identity");
+    request.setEntity(entity);
+
+    final HttpCoreContext context = HttpCoreContext.create();
+    context.setTargetHost(new HttpHost("localhost", 9201, "http"));
+
+    new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
+
+    final ContentType restoredContentType = ContentType.get(request.getEntity());
+    assertEquals(payload, EntityUtils.toString(request.getEntity(), StandardCharsets.UTF_8));
+    assertEquals(ContentType.APPLICATION_JSON.getMimeType(), restoredContentType.getMimeType());
+    assertEquals(StandardCharsets.UTF_8, restoredContentType.getCharset());
+    assertEquals("identity", request.getEntity().getContentEncoding().getValue());
+  }
+
+  /**
+   * Test that large payloads are truncated in the log but remain intact on the request.
+   *
+   * <p>The interceptor is meant to make requests replayable without letting DEBUG logging flood the
+   * application log. The truncation only applies to the log message; the full entity must be
+   * restored before OpenSearch receives the request.
+   */
+  @Test
+  void truncatesLargeLoggedPayloadAndPreservesFullRequestBody() throws Exception {
+    final String unloggedSuffix = "UNLOGGED_SUFFIX";
+    final String payload = "{\"query\":\"" + "a".repeat(100_100) + unloggedSuffix + "\"}";
+    final BasicHttpEntityEnclosingRequest request =
+        new BasicHttpEntityEnclosingRequest("POST", "/my-index/_search");
+    request.setEntity(
+        new StringEntity(
+            payload, ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8)));
+
+    final HttpCoreContext context = HttpCoreContext.create();
+    context.setTargetHost(new HttpHost("localhost", 9201, "http"));
+
+    new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
+
+    final String logMessage = appender.list.get(0).getFormattedMessage();
+    assertTrue(logMessage.contains("<... payload truncated after 100000 characters>"));
+    assertFalse(logMessage.contains(unloggedSuffix));
+    assertEquals(payload, EntityUtils.toString(request.getEntity(), StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Test that non-JSON payloads are not decoded or logged.
+   *
+   * <p>OpenSearch requests are expected to be JSON or newline-delimited JSON. If another content
+   * type reaches the interceptor, logging a placeholder avoids exposing unrelated request bodies
+   * and leaves the original entity untouched.
+   */
+  @Test
+  void doesNotLogNonJsonPayloads() throws Exception {
+    final String payload = "password=super-secret";
+    final BasicHttpEntityEnclosingRequest request =
+        new BasicHttpEntityEnclosingRequest("POST", "/my-index/_search");
+    request.setEntity(
+        new StringEntity(payload, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8)));
+
+    final HttpCoreContext context = HttpCoreContext.create();
+    context.setTargetHost(new HttpHost("localhost", 9201, "http"));
+
+    new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
+
+    final String logMessage = appender.list.get(0).getFormattedMessage();
+    assertTrue(logMessage.contains("<payload not logged: content type text/plain>"));
+    assertFalse(logMessage.contains("super-secret"));
+    assertEquals(payload, EntityUtils.toString(request.getEntity(), StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Test that payloads without content type are still logged as UTF-8 text.
+   *
+   * <p>The content-type guard allows missing content type because the OpenSearch client usually
+   * sends JSON but the low-level Apache entity metadata is not always guaranteed by callers.
+   */
+  @Test
+  void logsPayloadsWithoutContentType() throws Exception {
+    final String payload = "{\"query\":{\"match_all\":{}}}";
+    final BasicHttpEntityEnclosingRequest request =
+        new BasicHttpEntityEnclosingRequest("POST", "/my-index/_search");
+    request.setEntity(new ByteArrayEntity(payload.getBytes(StandardCharsets.UTF_8)));
+
+    final HttpCoreContext context = HttpCoreContext.create();
+    context.setTargetHost(new HttpHost("localhost", 9201, "http"));
+
+    new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
+
+    final String logMessage = appender.list.get(0).getFormattedMessage();
+    assertTrue(logMessage.contains(payload));
+    assertEquals(payload, EntityUtils.toString(request.getEntity(), StandardCharsets.UTF_8));
+  }
+
+  /** Test that requests without payloads still log a useful placeholder. */
+  @Test
+  void logsRequestsWithoutPayload() throws Exception {
+    final BasicHttpRequest request = new BasicHttpRequest("GET", "/_cluster/health");
+    final HttpCoreContext context = HttpCoreContext.create();
+    context.setTargetHost(new HttpHost("localhost", 9201, "http"));
+
+    new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
+
+    final String logMessage = appender.list.get(0).getFormattedMessage();
+    assertTrue(logMessage.contains("method = GET"));
+    assertTrue(logMessage.contains("url = http://localhost:9201/_cluster/health"));
+    assertTrue(logMessage.contains("parameters = <none>"));
+    assertTrue(logMessage.contains("index = <none>"));
+    assertTrue(logMessage.contains("payload =\n<none>"));
+  }
+}

--- a/src/test/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptorTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/configuration/EvsOpenSearchRequestLoggingInterceptorTest.java
@@ -20,9 +20,11 @@ import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.slf4j.LoggerFactory;
 
 /** Unit tests for {@link EvsOpenSearchRequestLoggingInterceptor}. */
+@ResourceLock("EvsOpenSearchRestTemplateLogger")
 class EvsOpenSearchRequestLoggingInterceptorTest {
 
   /** The logger used by the interceptor. */
@@ -60,6 +62,16 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
     logger.setAdditive(originalAdditive);
   }
 
+  /**
+   * Get the single request log emitted by the interceptor.
+   *
+   * @return the logged request message
+   */
+  private String getLoggedMessage() {
+    assertEquals(1, appender.list.size());
+    return appender.list.get(0).getFormattedMessage();
+  }
+
   /** Test that search requests log the actual request details and preserve the payload. */
   @Test
   void logsSearchRequestDetailsAndPreservesPayload() throws Exception {
@@ -94,7 +106,7 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
 
     new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
 
-    final String logMessage = appender.list.get(0).getFormattedMessage();
+    final String logMessage = getLoggedMessage();
     assertTrue(logMessage.contains("method = POST"));
     assertTrue(
         logMessage.contains(
@@ -160,7 +172,7 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
 
     new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
 
-    final String logMessage = appender.list.get(0).getFormattedMessage();
+    final String logMessage = getLoggedMessage();
     assertTrue(logMessage.contains("<... payload truncated after 100000 characters>"));
     assertFalse(logMessage.contains(unloggedSuffix));
     assertEquals(payload, EntityUtils.toString(request.getEntity(), StandardCharsets.UTF_8));
@@ -186,7 +198,7 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
 
     new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
 
-    final String logMessage = appender.list.get(0).getFormattedMessage();
+    final String logMessage = getLoggedMessage();
     assertTrue(logMessage.contains("<payload not logged: content type text/plain>"));
     assertFalse(logMessage.contains("super-secret"));
     assertEquals(payload, EntityUtils.toString(request.getEntity(), StandardCharsets.UTF_8));
@@ -210,7 +222,7 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
 
     new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
 
-    final String logMessage = appender.list.get(0).getFormattedMessage();
+    final String logMessage = getLoggedMessage();
     assertTrue(logMessage.contains(payload));
     assertEquals(payload, EntityUtils.toString(request.getEntity(), StandardCharsets.UTF_8));
   }
@@ -224,7 +236,7 @@ class EvsOpenSearchRequestLoggingInterceptorTest {
 
     new EvsOpenSearchRequestLoggingInterceptor().process(request, context);
 
-    final String logMessage = appender.list.get(0).getFormattedMessage();
+    final String logMessage = getLoggedMessage();
     assertTrue(logMessage.contains("method = GET"));
     assertTrue(logMessage.contains("url = http://localhost:9201/_cluster/health"));
     assertTrue(logMessage.contains("parameters = <none>"));

--- a/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
+++ b/src/test/java/gov/nih/nci/evs/api/controller/SearchControllerTests.java
@@ -7,27 +7,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-
 import gov.nih.nci.evs.api.model.Association;
 import gov.nih.nci.evs.api.model.Concept;
 import gov.nih.nci.evs.api.model.ConceptResultList;
@@ -44,6 +23,25 @@ import gov.nih.nci.evs.api.service.OpensearchQueryService;
 import gov.nih.nci.evs.api.util.ConceptUtils;
 import gov.nih.nci.evs.api.util.TerminologyUtils;
 import gov.nih.nci.evs.api.util.ThreadLocalMapper;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 /** Integration tests for SearchController. */
 @ExtendWith(SpringExtension.class)


### PR DESCRIPTION
https://tracker.nci.nih.gov/browse/EVSRESTAPI-440: Log details when making calls to elastic search

- the url
- the parameters
- the payload
- fields
- _source
- index

debug-gated as with the opensearch body logging