### PR TITLE
Pva/evsrestapi 698 use codesabs for rrfgenerator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ ext {
   if (!project.hasProperty("terminology")) {
     terminology = "na"
   }
+  if (!project.hasProperty("copyMode")) {
+    copyMode = "codesab"
+  }
 }
 
 /* Version info */
@@ -262,13 +265,13 @@ spotbugsTest {
 }
 
 // # for this, the cuis with listed sources will have hierarchies computed
-// ./gradlew rrfSample -Pterminology=NCIMTH,MDR,ICD10CM,ICD9CM,LNC,SNOMEDCT_US,RADLEX,PDQ,ICD10,HL7V3.0 -PlistFile=src/main/resources/cuis-202508.txt -PinputPath=../data/NCIM/META
+// ./gradlew rrfSample -Pterminology=NCIMTH,MDR,ICD10CM,ICD9CM,LNC,SNOMEDCT_US,RADLEX,PDQ,ICD10,HL7V3.0 -PlistFile=src/main/resources/cuis-202508.txt -PinputPath=../data/NCIM/META [-PcopyMode=codesab|cui]
 tasks.register('rrfSample', JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = "gov.nih.nci.evs.api.service.SamplingApplication"
   systemProperties System.getProperties()
   // arguments to pass to the application
-  args("rrfSample", inputPath, listFile, terminology)
+  args("rrfSample", inputPath, listFile, terminology, copyMode)
   jvmArgs "-Xmx8G"
 }
 

--- a/src/main/java/gov/nih/nci/evs/api/service/SamplingApplication.java
+++ b/src/main/java/gov/nih/nci/evs/api/service/SamplingApplication.java
@@ -35,18 +35,24 @@ public class SamplingApplication {
 
       // Sample RRF for a terminology
       if (command.equals("rrfSample")) {
-        if (args.length != 4) {
-          throw new Exception("Usage: ... rrfSample <inputPath> <list file> <terminology>");
+        if (args.length != 4 && args.length != 5) {
+          throw new Exception(
+              "Usage: ... rrfSample <inputPath> <list file> <terminology> [codesab|cui]");
         }
         final String inputPath = args[1];
         final String listFile = args[2];
         final String terminology = args[3];
+        final String copyMode = args.length == 5 ? args[4] : "codesab";
+        if (!"codesab".equalsIgnoreCase(copyMode) && !"cui".equalsIgnoreCase(copyMode)) {
+          throw new Exception("Copy mode must be codesab or cui: " + copyMode);
+        }
         // Generate subset to local directory
         SamplingApplication.rrfSample(
             "admin",
             inputPath,
             listFile,
-            Arrays.asList(terminology.split(",")).stream().collect(Collectors.toSet()));
+            Arrays.asList(terminology.split(",")).stream().collect(Collectors.toSet()),
+            "cui".equalsIgnoreCase(copyMode));
       }
 
     } catch (final Throwable t) {
@@ -98,12 +104,33 @@ public class SamplingApplication {
       final String listFile,
       final Set<String> terminologies)
       throws Exception {
+    rrfSample(username, inputPath, listFile, terminologies, false);
+  }
+
+  /**
+   * Rrf sample.
+   *
+   * @param username the username
+   * @param inputPath the input path
+   * @param listFile the list file
+   * @param terminologies the terminologies
+   * @param cuiMode the CUI copy mode
+   * @throws Exception the exception
+   */
+  public static void rrfSample(
+      final String username,
+      final String inputPath,
+      final String listFile,
+      final Set<String> terminologies,
+      final boolean cuiMode)
+      throws Exception {
 
     final RrfSampleGenerator generator = new RrfSampleGenerator();
     generator.setTerminologies(terminologies);
     generator.setCuisFile(listFile);
     generator.setInputPath(inputPath);
     generator.setKeepDescendants(false);
+    generator.setCuiMode(cuiMode);
     // generator.setDistanceOne(true);
     generator.compute();
   }

--- a/src/main/java/gov/nih/nci/evs/api/util/RrfFileCopier.java
+++ b/src/main/java/gov/nih/nci/evs/api/util/RrfFileCopier.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -47,6 +48,49 @@ public class RrfFileCopier {
       final Set<String> terminologies,
       final Set<String> cuis)
       throws Exception {
+    copyFiles(inputDir, outputDir, terminologies, cuis, null);
+  }
+
+  /**
+   * Copy files for the specified code/SAB values.
+   *
+   * @param inputDir the input dir
+   * @param outputDir the output dir
+   * @param terminologies the terminologies
+   * @param codesabs the code/SAB values to keep, encoded as {@code CODE|SAB}
+   * @throws Exception the exception
+   */
+  public void copyFilesByCodeSabs(
+      final File inputDir,
+      final File outputDir,
+      final Set<String> terminologies,
+      final Set<String> codesabs)
+      throws Exception {
+    copyFiles(
+        inputDir,
+        outputDir,
+        terminologies,
+        null,
+        buildCodeSabCopyScope(inputDir, codesabs == null ? Set.of() : codesabs));
+  }
+
+  /**
+   * Copy files.
+   *
+   * @param inputDir the input dir
+   * @param outputDir the output dir
+   * @param terminologies the terminologies
+   * @param cuis the cuis
+   * @param codeSabCopyScope the code/SAB copy scope
+   * @throws Exception the exception
+   */
+  private void copyFiles(
+      final File inputDir,
+      final File outputDir,
+      final Set<String> terminologies,
+      final Set<String> cuis,
+      final CodeSabCopyScope codeSabCopyScope)
+      throws Exception {
     logger.info("Start copying files");
 
     // Remove and remake output dir
@@ -76,7 +120,7 @@ public class RrfFileCopier {
       final File outputFile = new File(outputDir, inputFile.getName());
       logger.info("    input file = " + inputFile);
       logger.info("    output file = " + outputFile);
-      copyFile(inputFile, outputFile, key, cuis, terminologies);
+      copyFile(inputFile, outputFile, key, cuis, terminologies, codeSabCopyScope);
     }
 
     // release.dat, cnfig.prop
@@ -90,7 +134,7 @@ public class RrfFileCopier {
       final File outputFile = new File(outputDir, inputFile.getName());
       logger.info("    input file = " + inputFile);
       logger.info("    output file = " + outputFile);
-      copyFile(inputFile, outputFile, null, null, null);
+      copyFile(inputFile, outputFile, null, null, null, null);
     }
   }
 
@@ -102,6 +146,7 @@ public class RrfFileCopier {
    * @param key the key
    * @param cuis the cuis
    * @param sabs the sabs
+   * @param codeSabCopyScope the code/SAB copy scope
    * @throws Exception the exception
    */
   private void copyFile(
@@ -109,7 +154,8 @@ public class RrfFileCopier {
       final File outputFile,
       Keys key,
       final Set<String> cuis,
-      final Set<String> sabs)
+      final Set<String> sabs,
+      final CodeSabCopyScope codeSabCopyScope)
       throws Exception {
 
     final int[] cuiFields = key == null ? null : key.getCuiFields();
@@ -151,6 +197,570 @@ public class RrfFileCopier {
         // Otherwise, copy line.
         out.print(line + "\n");
       }
+    }
+  }
+
+  /**
+   * Builds the code/SAB copy scope from matching MRCONSO atoms.
+   *
+   * @param inputDir the input dir
+   * @param codesabs the code/SAB values
+   * @return the code/SAB copy scope
+   * @throws Exception the exception
+   */
+  private CodeSabCopyScope buildCodeSabCopyScope(final File inputDir, final Set<String> codesabs)
+      throws Exception {
+    final CodeSabCopyScope scope = new CodeSabCopyScope(codesabs);
+    final File inputFile = new File(inputDir, Keys.MRCONSO.name() + ".RRF");
+    if (!inputFile.exists()) {
+      return scope;
+    }
+
+    try (final BufferedReader in = new BufferedReader(new FileReader(inputFile)); ) {
+      String line;
+      long lineNumber = 0;
+      while ((line = in.readLine()) != null) {
+        lineNumber++;
+        final String[] fields = line.split("\\|", -1);
+        validateFieldCount(inputFile, Keys.MRCONSO, fields, lineNumber, 14);
+        if (!scope.containsCodeSab(fields[13], fields[11])) {
+          continue;
+        }
+        scope.addCui(fields[0]);
+        scope.addLui(fields[3]);
+        scope.addSui(fields[5]);
+        scope.addAui(fields[7]);
+        scope.addSaui(fields[8], fields[11]);
+        scope.addScui(fields[9], fields[11]);
+        scope.addSdui(fields[10], fields[11]);
+      }
+    }
+    logger.info("  Code/SAB copy scope codesabs = " + scope.getCodeSabs().size());
+    logger.info("  Code/SAB copy scope cuis = " + scope.getCuis().size());
+    logger.info("  Code/SAB copy scope auis = " + scope.getAuis().size());
+    return scope;
+  }
+
+  /**
+   * Indicates whether or not an RRF row matches the code/SAB copy scope.
+   *
+   * @param key the key
+   * @param fields the fields
+   * @param scope the code/SAB copy scope
+   * @return <code>true</code> if so, <code>false</code> otherwise
+   */
+  private boolean matchesCodeSabScope(
+      final Keys key, final String[] fields, final CodeSabCopyScope scope) {
+    if (key == null) {
+      return true;
+    }
+
+    switch (key) {
+      case MRCONSO:
+        return scope.containsCodeSab(fields[13], fields[11]);
+      case MRDEF:
+        return scope.containsAui(fields[1]);
+      case MRREL:
+        return matchesRelationshipEndpoint(fields[1], fields[2], fields[0], fields[10], scope)
+            && matchesRelationshipEndpoint(fields[5], fields[6], fields[4], fields[10], scope);
+      case MRHIER:
+        return scope.containsAui(fields[1]);
+      case MRSAT:
+        return matchesAttribute(fields, scope);
+      case MRSTY:
+        return scope.containsCui(fields[0]);
+      case MRCUI:
+        return scope.containsCui(fields[5]);
+      case MRMAP:
+        // MRMAP rows are CUI/mapset scoped, so code/SAB mode keeps all map rows for retained CUIs.
+        return scope.containsCui(fields[0]);
+      default:
+        return matchesCuiFields(key, fields, scope);
+    }
+  }
+
+  /**
+   * Returns the field count needed before the main copy filters run.
+   *
+   * @param key the key
+   * @return the field count
+   */
+  private int getPreFilterRequiredFieldCount(final Keys key) {
+    if (key == Keys.MRCUI) {
+      return 3;
+    }
+    return 0;
+  }
+
+  /**
+   * Returns the field count needed for the active copy filters.
+   *
+   * @param key the key
+   * @param cuis the CUIs
+   * @param codeSabCopyScope the code/SAB copy scope
+   * @return the field count
+   */
+  private int getRequiredFieldCount(
+      final Keys key, final Set<String> cuis, final CodeSabCopyScope codeSabCopyScope) {
+    if (key == null) {
+      return 0;
+    }
+
+    int requiredFieldCount = 0;
+    if (activeOnly && key == Keys.MRCONSO) {
+      requiredFieldCount = 17;
+    }
+
+    if (codeSabCopyScope != null) {
+      return Math.max(requiredFieldCount, getCodeSabRequiredFieldCount(key));
+    }
+
+    if (key.getCuiFields() != null && cuis != null && !cuis.isEmpty()) {
+      for (final int field : key.getCuiFields()) {
+        requiredFieldCount = Math.max(requiredFieldCount, field + 1);
+      }
+    }
+    return requiredFieldCount;
+  }
+
+  /**
+   * Returns the field count needed to apply code/SAB copy filters.
+   *
+   * @param key the key
+   * @return the field count
+   */
+  private int getCodeSabRequiredFieldCount(final Keys key) {
+    switch (key) {
+      case MRCONSO:
+        return 14;
+      case MRDEF:
+      case MRHIER:
+        return 2;
+      case MRREL:
+        return 11;
+      case MRSAT:
+        return 10;
+      case MRCUI:
+        return 6;
+      case MRMAP:
+      case MRSTY:
+        return 1;
+      default:
+        return getCuiRequiredFieldCount(key);
+    }
+  }
+
+  /**
+   * Returns the field count needed to read all configured CUI fields.
+   *
+   * @param key the key
+   * @return the field count
+   */
+  private int getCuiRequiredFieldCount(final Keys key) {
+    int requiredFieldCount = 0;
+    final int[] cuiFields = key.getCuiFields();
+    if (cuiFields != null) {
+      for (final int field : cuiFields) {
+        requiredFieldCount = Math.max(requiredFieldCount, field + 1);
+      }
+    }
+    return requiredFieldCount;
+  }
+
+  /**
+   * Validates that an RRF row has enough fields for this copier's filters.
+   *
+   * @param inputFile the input file
+   * @param key the key
+   * @param fields the fields
+   * @param lineNumber the line number
+   * @param requiredFieldCount the required field count
+   * @throws Exception the exception
+   */
+  private void validateFieldCount(
+      final File inputFile,
+      final Keys key,
+      final String[] fields,
+      final long lineNumber,
+      final int requiredFieldCount)
+      throws Exception {
+    if (fields.length < requiredFieldCount) {
+      throw new Exception(
+          "Malformed RRF row in "
+              + inputFile.getName()
+              + " ("
+              + key
+              + ") at line "
+              + lineNumber
+              + ": expected at least "
+              + requiredFieldCount
+              + " fields, found "
+              + fields.length);
+    }
+  }
+
+  /**
+   * Indicates whether or not an RRF row matches all CUI fields.
+   *
+   * @param key the key
+   * @param fields the fields
+   * @param scope the code/SAB copy scope
+   * @return <code>true</code> if so, <code>false</code> otherwise
+   */
+  private boolean matchesCuiFields(
+      final Keys key, final String[] fields, final CodeSabCopyScope scope) {
+    final int[] cuiFields = key.getCuiFields();
+    if (cuiFields == null) {
+      return true;
+    }
+    for (final int field : cuiFields) {
+      if (!scope.containsCui(fields[field])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Indicates whether or not an MRSAT row matches the code/SAB copy scope.
+   *
+   * @param fields the fields
+   * @param scope the code/SAB copy scope
+   * @return <code>true</code> if so, <code>false</code> otherwise
+   */
+  private boolean matchesAttribute(final String[] fields, final CodeSabCopyScope scope) {
+    final String metaUi = fields[3];
+    final String stype = fields[4];
+    final String code = fields[5];
+    final String sab = fields[9];
+
+    switch (stype) {
+      case "AUI":
+        return scope.containsAui(metaUi) || scope.containsAui(code);
+      case "CODE":
+        return scope.containsCodeSab(code, sab);
+      case "CUI":
+        return scope.containsCui(fields[0]) || scope.containsCui(code);
+      case "LUI":
+        return scope.containsLui(fields[1]) || scope.containsLui(metaUi) || scope.containsLui(code);
+      case "SUI":
+        return scope.containsSui(fields[2]) || scope.containsSui(metaUi) || scope.containsSui(code);
+      case "SAUI":
+        return scope.containsSaui(metaUi, sab) || scope.containsSaui(code, sab);
+      case "SCUI":
+        return scope.containsScui(metaUi, sab) || scope.containsScui(code, sab);
+      case "SDUI":
+        return scope.containsSdui(metaUi, sab) || scope.containsSdui(code, sab);
+      default:
+        return scope.containsCui(fields[0]);
+    }
+  }
+
+  /**
+   * Indicates whether or not an MRREL endpoint matches the code/SAB copy scope.
+   *
+   * @param identifier the endpoint identifier
+   * @param stype the endpoint identifier type
+   * @param cui the endpoint CUI
+   * @param sab the SAB
+   * @param scope the code/SAB copy scope
+   * @return <code>true</code> if so, <code>false</code> otherwise
+   */
+  private boolean matchesRelationshipEndpoint(
+      final String identifier,
+      final String stype,
+      final String cui,
+      final String sab,
+      final CodeSabCopyScope scope) {
+    if (identifier == null || identifier.isEmpty()) {
+      return scope.containsCui(cui);
+    }
+
+    switch (stype) {
+      case "AUI":
+        return scope.containsAui(identifier);
+      case "CODE":
+        return scope.containsCodeSab(identifier, sab);
+      case "CUI":
+        return scope.containsCui(identifier) || scope.containsCui(cui);
+      case "SAUI":
+        return scope.containsSaui(identifier, sab);
+      case "SCUI":
+        return scope.containsScui(identifier, sab);
+      case "SDUI":
+        return scope.containsSdui(identifier, sab);
+      default:
+        return scope.containsAui(identifier) || scope.containsCui(cui);
+    }
+  }
+
+  /** Code/SAB copy scope derived from matching MRCONSO rows. */
+  private static class CodeSabCopyScope {
+
+    /** The code/SAB values. */
+    private final Set<String> codeSabs;
+
+    /** The CUIs. */
+    private final Set<String> cuis = new HashSet<>();
+
+    /** The LUIs. */
+    private final Set<String> luis = new HashSet<>();
+
+    /** The SUIs. */
+    private final Set<String> suis = new HashSet<>();
+
+    /** The AUIs. */
+    private final Set<String> auis = new HashSet<>();
+
+    /** The SAUI/SAB values. */
+    private final Set<String> sauis = new HashSet<>();
+
+    /** The SCUI/SAB values. */
+    private final Set<String> scuis = new HashSet<>();
+
+    /** The SDUI/SAB values. */
+    private final Set<String> sduis = new HashSet<>();
+
+    /**
+     * Instantiates a new code/SAB copy scope.
+     *
+     * @param codeSabs the code/SAB values
+     */
+    private CodeSabCopyScope(final Set<String> codeSabs) {
+      this.codeSabs = new HashSet<>(codeSabs);
+    }
+
+    /**
+     * Returns the code/SAB values.
+     *
+     * @return the code/SAB values
+     */
+    private Set<String> getCodeSabs() {
+      return codeSabs;
+    }
+
+    /**
+     * Returns the CUIs.
+     *
+     * @return the CUIs
+     */
+    private Set<String> getCuis() {
+      return cuis;
+    }
+
+    /**
+     * Returns the AUIs.
+     *
+     * @return the AUIs
+     */
+    private Set<String> getAuis() {
+      return auis;
+    }
+
+    /**
+     * Adds a CUI.
+     *
+     * @param cui the CUI
+     */
+    private void addCui(final String cui) {
+      addIfPresent(cuis, cui);
+    }
+
+    /**
+     * Adds an LUI.
+     *
+     * @param lui the LUI
+     */
+    private void addLui(final String lui) {
+      addIfPresent(luis, lui);
+    }
+
+    /**
+     * Adds an SUI.
+     *
+     * @param sui the SUI
+     */
+    private void addSui(final String sui) {
+      addIfPresent(suis, sui);
+    }
+
+    /**
+     * Adds an AUI.
+     *
+     * @param aui the AUI
+     */
+    private void addAui(final String aui) {
+      addIfPresent(auis, aui);
+    }
+
+    /**
+     * Adds an SAUI/SAB value.
+     *
+     * @param saui the SAUI
+     * @param sab the SAB
+     */
+    private void addSaui(final String saui, final String sab) {
+      addSourceIdIfPresent(sauis, saui, sab);
+    }
+
+    /**
+     * Adds an SCUI/SAB value.
+     *
+     * @param scui the SCUI
+     * @param sab the SAB
+     */
+    private void addScui(final String scui, final String sab) {
+      addSourceIdIfPresent(scuis, scui, sab);
+    }
+
+    /**
+     * Adds an SDUI/SAB value.
+     *
+     * @param sdui the SDUI
+     * @param sab the SAB
+     */
+    private void addSdui(final String sdui, final String sab) {
+      addSourceIdIfPresent(sduis, sdui, sab);
+    }
+
+    /**
+     * Indicates whether or not the code/SAB value is included.
+     *
+     * @param code the code
+     * @param sab the SAB
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsCodeSab(final String code, final String sab) {
+      if (code == null || code.isEmpty() || sab == null || sab.isEmpty()) {
+        return false;
+      }
+      return codeSabs.contains(toCodeSab(code, sab));
+    }
+
+    /**
+     * Indicates whether or not the CUI is included.
+     *
+     * @param cui the CUI
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsCui(final String cui) {
+      return cuis.contains(cui);
+    }
+
+    /**
+     * Indicates whether or not the LUI is included.
+     *
+     * @param lui the LUI
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsLui(final String lui) {
+      return luis.contains(lui);
+    }
+
+    /**
+     * Indicates whether or not the SUI is included.
+     *
+     * @param sui the SUI
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsSui(final String sui) {
+      return suis.contains(sui);
+    }
+
+    /**
+     * Indicates whether or not the AUI is included.
+     *
+     * @param aui the AUI
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsAui(final String aui) {
+      return auis.contains(aui);
+    }
+
+    /**
+     * Indicates whether or not the SAUI/SAB value is included.
+     *
+     * @param saui the SAUI
+     * @param sab the SAB
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsSaui(final String saui, final String sab) {
+      return containsSourceId(sauis, saui, sab);
+    }
+
+    /**
+     * Indicates whether or not the SCUI/SAB value is included.
+     *
+     * @param scui the SCUI
+     * @param sab the SAB
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsScui(final String scui, final String sab) {
+      return containsSourceId(scuis, scui, sab);
+    }
+
+    /**
+     * Indicates whether or not the SDUI/SAB value is included.
+     *
+     * @param sdui the SDUI
+     * @param sab the SAB
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsSdui(final String sdui, final String sab) {
+      return containsSourceId(sduis, sdui, sab);
+    }
+
+    /**
+     * Adds the value to the set when it is present.
+     *
+     * @param values the values
+     * @param value the value
+     */
+    private void addIfPresent(final Set<String> values, final String value) {
+      if (value != null && !value.isEmpty()) {
+        values.add(value);
+      }
+    }
+
+    /**
+     * Adds the source identifier/SAB value to the set when both parts are present.
+     *
+     * @param values the values
+     * @param sourceId the source identifier
+     * @param sab the SAB
+     */
+    private void addSourceIdIfPresent(
+        final Set<String> values, final String sourceId, final String sab) {
+      if (sourceId != null && !sourceId.isEmpty() && sab != null && !sab.isEmpty()) {
+        values.add(toCodeSab(sourceId, sab));
+      }
+    }
+
+    /**
+     * Indicates whether or not the source identifier/SAB value is included.
+     *
+     * @param values the values
+     * @param sourceId the source identifier
+     * @param sab the SAB
+     * @return <code>true</code> if so, <code>false</code> otherwise
+     */
+    private boolean containsSourceId(
+        final Set<String> values, final String sourceId, final String sab) {
+      if (sourceId == null || sourceId.isEmpty() || sab == null || sab.isEmpty()) {
+        return false;
+      }
+      return values.contains(toCodeSab(sourceId, sab));
+    }
+
+    /**
+     * Returns a code/SAB value.
+     *
+     * @param code the code
+     * @param sab the SAB
+     * @return the code/SAB value
+     */
+    private String toCodeSab(final String code, final String sab) {
+      return code + "|" + sab;
     }
   }
 

--- a/src/main/java/gov/nih/nci/evs/api/util/RrfFileCopier.java
+++ b/src/main/java/gov/nih/nci/evs/api/util/RrfFileCopier.java
@@ -166,9 +166,12 @@ public class RrfFileCopier {
     try (final BufferedReader in = new BufferedReader(new FileReader(inputFile));
         PrintWriter out = new PrintWriter(new FileWriter(outputFile)); ) {
       String line;
+      long lineNumber = 0;
       OUTER:
       while ((line = in.readLine()) != null) {
+        lineNumber++;
         final String[] fields = line.split("\\|", -1);
+        validateFieldCount(inputFile, key, fields, lineNumber, getPreFilterRequiredFieldCount(key));
 
         // If MRCUI and it is a DEL entry, then keep
         if (key == Keys.MRCUI && "DEL".equals(fields[2])) {
@@ -176,8 +179,16 @@ public class RrfFileCopier {
           continue;
         }
 
+        validateFieldCount(
+            inputFile, key, fields, lineNumber, getRequiredFieldCount(key, cuis, codeSabCopyScope));
+
+        // In code/SAB mode, keep only matching atoms and downstream rows scoped to those atoms.
+        if (codeSabCopyScope != null && !matchesCodeSabScope(key, fields, codeSabCopyScope)) {
+          continue;
+        }
+
         // Skip non-matching CUI
-        if (cuiFields != null && cuis != null && !cuis.isEmpty()) {
+        if (codeSabCopyScope == null && cuiFields != null && cuis != null && !cuis.isEmpty()) {
           for (final int i : cuiFields) {
             if (!cuis.contains(fields[i])) {
               continue OUTER;

--- a/src/main/java/gov/nih/nci/evs/api/util/RrfSampleGenerator.java
+++ b/src/main/java/gov/nih/nci/evs/api/util/RrfSampleGenerator.java
@@ -40,6 +40,9 @@ public class RrfSampleGenerator {
   /** The distance one. */
   private boolean distanceOne = true;
 
+  /** The cui mode. */
+  private boolean cuiMode = false;
+
   /** The chd par map. */
   private Map<String, Set<String>> chdParMap = new HashMap<>();
 
@@ -99,6 +102,7 @@ public class RrfSampleGenerator {
       logger.info("  terminologies = " + terminologies);
       logger.info("  keepDescendants = " + keepDescendants);
       logger.info("  distanceOne = " + distanceOne);
+      logger.info("  cuiMode = " + cuiMode);
 
       // Verify input path
       final File file = new File(inputPath);
@@ -263,17 +267,21 @@ public class RrfSampleGenerator {
       cuis.addAll(inputCuis);
 
       logger.info("    cuis = " + cuis.size());
+      final Set<String> nonNullCodesabs =
+          codesabs.stream().filter(s -> s != null).collect(Collectors.toSet());
+      logger.info("    codesabs = " + nonNullCodesabs.size());
 
       readers.closeReaders();
 
       // Copy Files
       final RrfFileCopier copier = new RrfFileCopier();
-      // Parameterize this!
       final File outputDir = new File(inputPath, "/RRF-subset/");
       copier.setActiveOnly(false);
-      // NOTE: we probably should pass in codesabs here and keep atoms
-      // that match them and then other downstream data matching those AUIs only.
-      copier.copyFiles(new File(inputPath), outputDir, terminologies, cuis);
+      if (cuiMode) {
+        copier.copyFiles(new File(inputPath), outputDir, terminologies, cuis);
+      } else {
+        copier.copyFilesByCodeSabs(new File(inputPath), outputDir, terminologies, nonNullCodesabs);
+      }
 
       logger.info("Done ...");
 
@@ -503,6 +511,15 @@ public class RrfSampleGenerator {
    */
   public void setDistanceOne(final boolean distanceOne) {
     this.distanceOne = distanceOne;
+  }
+
+  /**
+   * Sets the CUI mode.
+   *
+   * @param cuiMode the CUI mode
+   */
+  public void setCuiMode(final boolean cuiMode) {
+    this.cuiMode = cuiMode;
   }
 
   /**

--- a/src/main/resources/cuis-202508.txt
+++ b/src/main/resources/cuis-202508.txt
@@ -1,7 +1,6 @@
 # MRMAP CUIs
 C3645705
 CL1777919
-CL1948316
 # CUIs from UnitTestData/NCIM (taken from prior CUI file and updated through MRCUI)
 C0000005
 C0000039

--- a/src/test/java/gov/nih/nci/evs/api/util/RrfFileCopierUnitTest.java
+++ b/src/test/java/gov/nih/nci/evs/api/util/RrfFileCopierUnitTest.java
@@ -1,0 +1,169 @@
+package gov.nih.nci.evs.api.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for {@link RrfFileCopier}. */
+public class RrfFileCopierUnitTest {
+
+  /** The temp dir. */
+  @TempDir Path tempDir;
+
+  /** Test that CUI copy mode keeps all rows for a matching CUI. */
+  @Test
+  public void copyFilesKeepsWholeCuisInCuiMode() throws Exception {
+    final Path inputDir = createInputDir();
+    final Path outputDir = tempDir.resolve("output-cui");
+
+    final RrfFileCopier copier = new RrfFileCopier();
+    copier.copyFiles(inputDir.toFile(), outputDir.toFile(), Set.of("SAB"), Set.of("C0001"));
+
+    assertThat(readLines(outputDir, "MRCONSO.RRF"))
+        .containsExactly(
+            "C0001|ENG|P|L1|PF|S1|Y|A1|SA1|SC1|SD1|SAB|PT|CODE1|Name one|0|N|256|",
+            "C0001|ENG|P|L2|PF|S2|Y|A2|SA2|SC2|SD2|SAB|SY|CODE2|Name two|0|N|256|");
+    assertThat(readLines(outputDir, "MRDEF.RRF"))
+        .containsExactly(
+            "C0001|A1|AT1|SAT1|SAB|Definition one|N|256|",
+            "C0001|A2|AT2|SAT2|SAB|Definition two|N|256|");
+  }
+
+  /** Test that code/SAB copy mode keeps only matching atoms and atom-scoped rows. */
+  @Test
+  public void copyFilesByCodeSabsKeepsOnlyMatchingCodeSabRows() throws Exception {
+    final Path inputDir = createInputDir();
+    final Path outputDir = tempDir.resolve("output-codesab");
+
+    final RrfFileCopier copier = new RrfFileCopier();
+    copier.copyFilesByCodeSabs(
+        inputDir.toFile(), outputDir.toFile(), Set.of("SAB"), Set.of("CODE1|SAB"));
+
+    assertThat(readLines(outputDir, "MRCONSO.RRF"))
+        .containsExactly("C0001|ENG|P|L1|PF|S1|Y|A1|SA1|SC1|SD1|SAB|PT|CODE1|Name one|0|N|256|");
+    assertThat(readLines(outputDir, "MRDEF.RRF"))
+        .containsExactly("C0001|A1|AT1|SAT1|SAB|Definition one|N|256|");
+    assertThat(readLines(outputDir, "MRSAT.RRF"))
+        .containsExactly(
+            "C0001|L1|S1|A1|AUI|CODE1|AT1|SAT1|ATTR|SAB|Atom attr one|N|256|",
+            "C0001|L1|S1||CODE|CODE1|AT3|SAT3|ATTR|SAB|Code attr one|N|256|");
+    assertThat(readLines(outputDir, "MRREL.RRF"))
+        .containsExactly("C0001|A1|AUI|RO|C0001|A1|AUI|related_to|R0|SR0|SAB|SAB||Y|N||");
+    assertThat(readLines(outputDir, "MRHIER.RRF")).containsExactly("C0001|A1|CXN1||SAB|isa||HCD1|");
+    assertThat(readLines(outputDir, "MRMAP.RRF"))
+        .containsExactly("C0001|SAB|MAP1|CODE1|", "C0001|SAB|MAP2|CODE2|");
+    assertThat(readLines(outputDir, "MRCUI.RRF"))
+        .containsExactly("C9999|202401|DEL||||Y|", "C9998|202401|RB||reason|C0001|Y|");
+  }
+
+  /** Test that malformed RRF rows report the file, key, and line number. */
+  @Test
+  public void copyFilesByCodeSabsReportsMalformedRows() throws Exception {
+    final Path inputDir = tempDir.resolve("malformed-input");
+    final Path outputDir = tempDir.resolve("malformed-output");
+    Files.createDirectories(inputDir);
+    writeLines(inputDir, "MRCONSO.RRF", List.of("C0001|ENG|P|L1"));
+
+    final RrfFileCopier copier = new RrfFileCopier();
+
+    assertThatThrownBy(
+            () ->
+                copier.copyFilesByCodeSabs(
+                    inputDir.toFile(), outputDir.toFile(), Set.of("SAB"), Set.of("CODE1|SAB")))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("Malformed RRF row in MRCONSO.RRF (MRCONSO) at line 1")
+        .hasMessageContaining("expected at least 14 fields, found 4");
+  }
+
+  /**
+   * Creates an input directory with tiny RRF fixtures.
+   *
+   * @return the input directory
+   * @throws Exception if anything goes wrong
+   */
+  private Path createInputDir() throws Exception {
+    final Path inputDir = tempDir.resolve("input-" + System.nanoTime());
+    Files.createDirectories(inputDir);
+
+    writeLines(
+        inputDir,
+        "MRCONSO.RRF",
+        List.of(
+            "C0001|ENG|P|L1|PF|S1|Y|A1|SA1|SC1|SD1|SAB|PT|CODE1|Name one|0|N|256|",
+            "C0001|ENG|P|L2|PF|S2|Y|A2|SA2|SC2|SD2|SAB|SY|CODE2|Name two|0|N|256|",
+            "C0002|ENG|P|L3|PF|S3|Y|A3|SA3|SC3|SD3|SAB|PT|CODE3|Name three|0|N|256|"));
+    writeLines(
+        inputDir,
+        "MRDEF.RRF",
+        List.of(
+            "C0001|A1|AT1|SAT1|SAB|Definition one|N|256|",
+            "C0001|A2|AT2|SAT2|SAB|Definition two|N|256|",
+            "C0002|A3|AT3|SAT3|SAB|Definition three|N|256|"));
+    writeLines(
+        inputDir,
+        "MRSAT.RRF",
+        List.of(
+            "C0001|L1|S1|A1|AUI|CODE1|AT1|SAT1|ATTR|SAB|Atom attr one|N|256|",
+            "C0001|L2|S2|A2|AUI|CODE2|AT2|SAT2|ATTR|SAB|Atom attr two|N|256|",
+            "C0001|L1|S1||CODE|CODE1|AT3|SAT3|ATTR|SAB|Code attr one|N|256|",
+            "C0001|L2|S2||CODE|CODE2|AT4|SAT4|ATTR|SAB|Code attr two|N|256|"));
+    writeLines(
+        inputDir,
+        "MRREL.RRF",
+        List.of(
+            "C0001|A1|AUI|RO|C0001|A1|AUI|related_to|R0|SR0|SAB|SAB||Y|N||",
+            "C0001|A1|AUI|RO|C0001|A2|AUI|related_to|R1|SR1|SAB|SAB||Y|N||",
+            "C0001|A2|AUI|RO|C0002|A3|AUI|related_to|R2|SR2|SAB|SAB||Y|N||"));
+    writeLines(
+        inputDir,
+        "MRHIER.RRF",
+        List.of(
+            "C0001|A1|CXN1||SAB|isa||HCD1|",
+            "C0001|A2|CXN2||SAB|isa||HCD2|",
+            "C0002|A3|CXN3||SAB|isa||HCD3|"));
+    writeLines(
+        inputDir,
+        "MRMAP.RRF",
+        List.of("C0001|SAB|MAP1|CODE1|", "C0001|SAB|MAP2|CODE2|", "C0002|SAB|MAP3|CODE3|"));
+    writeLines(
+        inputDir,
+        "MRCUI.RRF",
+        List.of(
+            "C9999|202401|DEL||||Y|",
+            "C9998|202401|RB||reason|C0001|Y|",
+            "C9997|202401|RB||reason|C0002|Y|"));
+    return inputDir;
+  }
+
+  /**
+   * Writes lines to a fixture file.
+   *
+   * @param dir the directory
+   * @param file the file
+   * @param lines the lines
+   * @throws Exception if anything goes wrong
+   */
+  private void writeLines(final Path dir, final String file, final List<String> lines)
+      throws Exception {
+    Files.write(dir.resolve(file), lines, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Reads lines from an output file.
+   *
+   * @param dir the directory
+   * @param file the file
+   * @return the lines
+   * @throws Exception if anything goes wrong
+   */
+  private List<String> readLines(final Path dir, final String file) throws Exception {
+    return Files.readAllLines(dir.resolve(file), StandardCharsets.UTF_8);
+  }
+}


### PR DESCRIPTION
https://tracker.nci.nih.gov/browse/EVSRESTAPI-698: use codesabs for rrfgenerator

- Updates RRF sample generation to copy rows by the selected code/SAB pairs instead of keeping every row for the matching CUIs, while preserving the old CUI-based copy mode as an option.

- Narrows atom-scoped downstream RRF content like definitions, attributes, relationships, and hierarchy rows to the retained atoms, with explicit handling for CUI/mapset-scoped files.

- Unit tests where appropriate